### PR TITLE
Add gene coverage columns during ingest workflow

### DIFF
--- a/ingest/bin/calculate-gene-converage-from-nextclade-translation.py
+++ b/ingest/bin/calculate-gene-converage-from-nextclade-translation.py
@@ -9,7 +9,7 @@ import re
 
 def parse_args():
     parser = argparse.ArgumentParser(
-        description="Calculate gene coverage from amino acid sequence",
+        description="Calculate gene coverage from amino acid sequence. The output will be in TSV format to stdout.",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     parser.add_argument(

--- a/ingest/bin/calculate-gene-converage-from-nextclade-translation.py
+++ b/ingest/bin/calculate-gene-converage-from-nextclade-translation.py
@@ -1,0 +1,54 @@
+#! /usr/bin/env python3
+
+import argparse
+from sys import stderr
+
+from Bio import SeqIO
+import re
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Calculate gene coverage from amino acid sequence",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--fasta",
+        type=str,
+        help="FASTA file of CDS translations from Nextclade.",
+    )
+    parser.add_argument(
+        "--out-col",
+        type=str,
+        default="gene_coverage",
+        help="Output column name.",
+    )
+    return parser.parse_args()
+
+
+def calculate_gene_coverage_from_nextclade_cds(fasta, out_col):
+    """
+    Calculate gene coverage from amino acid sequence in gene translation FASTA file from Nextclade.
+    """
+    print(f"genbank_accession\t{out_col}")
+    # Iterate over the sequences in the FASTA file
+    for record in SeqIO.parse(fasta, "fasta"):
+        sequence_id = record.id
+        sequence = str(record.seq)
+        
+        # Calculate gene coverage
+        results = re.findall(r"([ACDEFGHIKLMNPQRSTVWY])",  sequence.upper())
+        gene_coverage = round(len(results) / len(sequence), 3)
+
+        # Print the results
+        print(f"{sequence_id}\t{gene_coverage}")
+
+
+def main():
+    args = parse_args()
+
+    calculate_gene_coverage_from_nextclade_cds(args.fasta, args.out_col)
+
+
+if __name__ == "__main__":
+    main()

--- a/ingest/defaults/config.yaml
+++ b/ingest/defaults/config.yaml
@@ -111,3 +111,5 @@ nextclade:
   min_seed_cover: 0.1
   nextclade_field: 'nextclade_subtype'
   gene: ['E','NS1']
+  input_nextclade_fields: "seqName,clade,alignmentStart,alignmentEnd,coverage,failedCdses"
+  output_nextclade_fields: "alignmentStart,alignmentEnd,genome_coverage,failedCdses"

--- a/ingest/defaults/config.yaml
+++ b/ingest/defaults/config.yaml
@@ -109,7 +109,12 @@ curate:
 nextclade:
   min_length: 1000 # E gene length is approximately 1400nt
   min_seed_cover: 0.1
-  nextclade_field: 'nextclade_subtype'
   gene: ['E','NS1']
-  input_nextclade_fields: "seqName,clade,alignmentStart,alignmentEnd,coverage,failedCdses"
-  output_nextclade_fields: "alignmentStart,alignmentEnd,genome_coverage,failedCdses"
+  # Nextclade Fields to rename to metadata field names.
+  field_map:
+    seqName: genbank_accession # ID field used to merge annotations
+    clade: nextclade_subtype
+    alignmentStart: alignmentStart
+    alignmentEnd: alignmentEnd
+    coverage: genome_coverage
+    failedCdses: failedCdses

--- a/ingest/defaults/config.yaml
+++ b/ingest/defaults/config.yaml
@@ -110,3 +110,4 @@ nextclade:
   min_length: 1000 # E gene length is approximately 1400nt
   min_seed_cover: 0.1
   nextclade_field: 'nextclade_subtype'
+  gene: ['E','NS1']

--- a/ingest/rules/nextclade.smk
+++ b/ingest/rules/nextclade.smk
@@ -30,12 +30,12 @@ rule nextclade_denvX:
     output:
         nextclade_denvX="data/nextclade_results/nextclade_{serotype}.tsv",
         nextclade_alignment="results/aligned_{serotype}.fasta",
-        nextclade_translations=expand("data/translations/seqs_{{serotype}}.gene.{gene}.fasta", gene=config["nextclade"]["gene"]),
+        nextclade_translations=expand("data/translations/{{serotype}}/{gene}/seqs.gene.fasta", gene=config["nextclade"]["gene"]),
     threads: 4
     params:
         min_length=config["nextclade"]["min_length"],
         min_seed_cover=config["nextclade"]["min_seed_cover"],
-        output_translations = lambda wildcards: f"data/translations/seqs_{wildcards.serotype}.gene.{{cds}}.fasta",
+        output_translations = lambda wildcards: f"data/translations/{wildcards.serotype}/{{cds}}/seqs.gene.fasta",
     wildcard_constraints:
         serotype=SEROTYPE_CONSTRAINTS
     shell:
@@ -105,9 +105,9 @@ rule calculate_gene_coverage:
     Calculate the coverage of the gene of interest
     """
     input:
-        nextclade_translation="data/translations/seqs_{serotype}.gene.{gene}.fasta",
+        nextclade_translation="data/translations/{serotype}/{gene}/seqs.gene.fasta",
     output:
-        gene_coverage="data/translations/gene_coverage_{serotype}_{gene}.tsv",
+        gene_coverage="data/translations/{serotype}/{gene}/gene_coverage.tsv",
     wildcard_constraints:
         serotype=SEROTYPE_CONSTRAINTS,
     shell:
@@ -123,9 +123,9 @@ rule aggregate_gene_coverage_by_gene:
     Aggregate the gene coverage results by gene
     """
     input:
-        gene_coverage=expand("data/translations/gene_coverage_{serotype}_{{gene}}.tsv", serotype=SUPPORTED_NEXTCLADE_SEROTYPES),
+        gene_coverage=expand("data/translations/{serotype}/{{gene}}/gene_coverage.tsv", serotype=SUPPORTED_NEXTCLADE_SEROTYPES),
     output:
-        gene_coverage_all="results/gene_coverage_all_{gene}.tsv",
+        gene_coverage_all="results/{gene}/gene_coverage_all.tsv",
     shell:
         """
         tsv-append -H {input.gene_coverage} > {output.gene_coverage_all}
@@ -137,7 +137,7 @@ rule append_gene_coverage_columns:
     """
     input:
         metadata="data/metadata_nextclade.tsv",
-        gene_coverage=expand("results/gene_coverage_all_{gene}.tsv", gene=config["nextclade"]["gene"])
+        gene_coverage=expand("results/{gene}/gene_coverage_all.tsv", gene=config["nextclade"]["gene"])
     output:
         metadata_all="results/metadata_all.tsv",
     params:

--- a/ingest/rules/nextclade.smk
+++ b/ingest/rules/nextclade.smk
@@ -61,13 +61,11 @@ rule concat_nextclade_subtype_results:
     output:
         nextclade_subtypes="results/nextclade_subtypes.tsv",
     params:
-        id_field=config["curate"]["id_field"],
-        nextclade_field=config["nextclade"]["nextclade_field"],
-        input_nextclade_fields=config["nextclade"]["input_nextclade_fields"],
-        output_nextclade_fields=config["nextclade"]["output_nextclade_fields"],
+        input_nextclade_fields=",".join([f'{key}' for key, value in config["nextclade"]["field_map"].items()]),
+        output_nextclade_fields=",".join([f'{value}' for key, value in config["nextclade"]["field_map"].items()]),
     shell:
         """
-        echo "{params.id_field},{params.nextclade_field},{params.output_nextclade_fields}" \
+        echo "{params.output_nextclade_fields}" \
         | tr ',' '\t' \
         > {output.nextclade_subtypes}
 
@@ -86,15 +84,14 @@ rule append_nextclade_columns:
     output:
         metadata_all="data/metadata_nextclade.tsv",
     params:
-        id_field=config["curate"]["id_field"],
-        nextclade_field=config["nextclade"]["nextclade_field"],
-        output_nextclade_fields=config["nextclade"]["output_nextclade_fields"],
+        id_field=list(config["nextclade"]["field_map"].values())[0],
+        output_nextclade_fields=",".join([f'{value}' for key, value in config["nextclade"]["field_map"].items()][1:]),
     shell:
         """
         tsv-join -H \
             --filter-file {input.nextclade_subtypes} \
             --key-fields {params.id_field} \
-            --append-fields {params.nextclade_field},{params.output_nextclade_fields} \
+            --append-fields {params.output_nextclade_fields} \
             --write-all ? \
             {input.metadata} \
         > {output.metadata_all}

--- a/ingest/rules/nextclade.smk
+++ b/ingest/rules/nextclade.smk
@@ -63,13 +63,15 @@ rule concat_nextclade_subtype_results:
     params:
         id_field=config["curate"]["id_field"],
         nextclade_field=config["nextclade"]["nextclade_field"],
+        input_nextclade_fields=config["nextclade"]["input_nextclade_fields"],
+        output_nextclade_fields=config["nextclade"]["output_nextclade_fields"],
     shell:
         """
-        echo "{params.id_field},{params.nextclade_field},alignmentStart,alignmentEnd,genome_coverage,failedCdses" \
+        echo "{params.id_field},{params.nextclade_field},{params.output_nextclade_fields}" \
         | tr ',' '\t' \
         > {output.nextclade_subtypes}
 
-        tsv-select -H -f "seqName,clade,alignmentStart,alignmentEnd,coverage,failedCdses" {input.nextclade_results_files} \
+        tsv-select -H -f "{params.input_nextclade_fields}" {input.nextclade_results_files} \
         | awk 'NR>1 {{print}}' \
         >> {output.nextclade_subtypes}
         """
@@ -86,12 +88,13 @@ rule append_nextclade_columns:
     params:
         id_field=config["curate"]["id_field"],
         nextclade_field=config["nextclade"]["nextclade_field"],
+        output_nextclade_fields=config["nextclade"]["output_nextclade_fields"],
     shell:
         """
         tsv-join -H \
             --filter-file {input.nextclade_subtypes} \
             --key-fields {params.id_field} \
-            --append-fields {params.nextclade_field},alignmentStart,alignmentEnd,genome_coverage,failedCdses \
+            --append-fields {params.nextclade_field},{params.output_nextclade_fields} \
             --write-all ? \
             {input.metadata} \
         > {output.metadata_all}

--- a/ingest/rules/nextclade.smk
+++ b/ingest/rules/nextclade.smk
@@ -65,13 +65,12 @@ rule concat_nextclade_subtype_results:
         nextclade_field=config["nextclade"]["nextclade_field"],
     shell:
         """
-        echo "{params.id_field},{params.nextclade_field},alignmentStart,alignmentEnd,genome_coverage,failedCdses,E_indicator" \
+        echo "{params.id_field},{params.nextclade_field},alignmentStart,alignmentEnd,genome_coverage,failedCdses" \
         | tr ',' '\t' \
         > {output.nextclade_subtypes}
 
         tsv-select -H -f "seqName,clade,alignmentStart,alignmentEnd,coverage,failedCdses" {input.nextclade_results_files} \
         | awk 'NR>1 {{print}}' \
-        | awk -F'\t' '$2 && !($6 ~ /E/) {{print $0"\t1"; next}} {{print $0"\t"}}' \
         >> {output.nextclade_subtypes}
         """
 
@@ -92,7 +91,7 @@ rule append_nextclade_columns:
         tsv-join -H \
             --filter-file {input.nextclade_subtypes} \
             --key-fields {params.id_field} \
-            --append-fields {params.nextclade_field},alignmentStart,alignmentEnd,genome_coverage,failedCdses,E_indicator \
+            --append-fields {params.nextclade_field},alignmentStart,alignmentEnd,genome_coverage,failedCdses \
             --write-all ? \
             {input.metadata} \
         > {output.metadata_all}

--- a/ingest/rules/nextclade.smk
+++ b/ingest/rules/nextclade.smk
@@ -143,11 +143,10 @@ rule append_gene_coverage_columns:
         """
         cp {input.metadata} {output.metadata_all}
         for FILE in {input.gene_coverage}; do
-            export append_col=`awk 'NR==1 {{print $2}}' $FILE`
             tsv-join -H \
                 --filter-file $FILE \
                 --key-fields {params.id_field} \
-                --append-fields $append_col \
+                --append-fields '*_coverage' \
                 --write-all ? \
                 {output.metadata_all} \
             > results/temp_aggregate_gene_coverage.tsv

--- a/ingest/rules/nextclade.smk
+++ b/ingest/rules/nextclade.smk
@@ -19,16 +19,22 @@ SEROTYPE_CONSTRAINTS = '|'.join(SUPPORTED_NEXTCLADE_SEROTYPES)
 rule nextclade_denvX:
     """
     For each type, classify into the appropriate subtype
+    1. Capture the alignment
+    2. Capture the translations of gene(s) of interest
     """
     input:
         sequences="results/sequences_{serotype}.fasta",
         dataset="../nextclade_data/{serotype}",
     output:
         nextclade_denvX="data/nextclade_results/nextclade_{serotype}.tsv",
+        nextclade_alignment="results/nextclade_aligned_sequences_{serotype}.fasta",
+        nextclade_translations=expand("results/translations/seqs_{{serotype}}.gene.{gene}.fasta", gene=config["nextclade"]["gene"]),
     threads: 4
     params:
         min_length=config["nextclade"]["min_length"],
         min_seed_cover=config["nextclade"]["min_seed_cover"],
+        gene=config["nextclade"]["gene"],
+        output_translations = lambda wildcards: f"results/translations/seqs_{wildcards.serotype}.gene.{{cds}}.fasta",
     wildcard_constraints:
         serotype=SEROTYPE_CONSTRAINTS
     shell:
@@ -40,6 +46,9 @@ rule nextclade_denvX:
           --min-length {params.min_length} \
           --min-seed-cover {params.min_seed_cover} \
           --silent \
+          --output-fasta {output.nextclade_alignment} \
+          --cds-selection {params.gene} \
+          --output-translations {params.output_translations} \
           {input.sequences}
         """
 

--- a/ingest/rules/nextclade.smk
+++ b/ingest/rules/nextclade.smk
@@ -56,11 +56,11 @@ rule concat_nextclade_subtype_results:
         nextclade_field=config["nextclade"]["nextclade_field"],
     shell:
         """
-        echo "{params.id_field},{params.nextclade_field}" \
+        echo "{params.id_field},{params.nextclade_field},alignmentStart,alignmentEnd" \
         | tr ',' '\t' \
         > {output.nextclade_subtypes}
 
-        tsv-select -H -f "seqName,clade" {input} \
+        tsv-select -H -f "seqName,clade,alignmentStart,alignmentEnd" {input} \
         | awk 'NR>1 {{print}}' \
         >> {output.nextclade_subtypes}
         """
@@ -82,7 +82,7 @@ rule append_nextclade_columns:
         tsv-join -H \
             --filter-file {input.nextclade_subtypes} \
             --key-fields {params.id_field} \
-            --append-fields {params.nextclade_field} \
+            --append-fields {params.nextclade_field},alignmentStart,alignmentEnd \
             --write-all ? \
             {input.metadata} \
         > {output.metadata_all}

--- a/ingest/rules/nextclade.smk
+++ b/ingest/rules/nextclade.smk
@@ -126,12 +126,7 @@ rule aggregate_gene_coverage_by_gene:
         gene_coverage_all="results/gene_coverage_all_{gene}.tsv",
     shell:
         """
-        # Capture header for tsv
-        head -n1 {input.gene_coverage[0]} > {output.gene_coverage_all}
-        # Capture rest of tsv lines from all files
-        for FILE in {input.gene_coverage}; do
-            awk 'NR>1' $FILE >> {output.gene_coverage_all}
-        done
+        tsv-append -H {input.gene_coverage} > {output.gene_coverage_all}
         """
 
 rule append_gene_coverage_columns:


### PR DESCRIPTION
## Description of proposed changes

![pathogen-repo-guide (6)](https://github.com/nextstrain/dengue/assets/1077254/26e4b9a2-b04d-434d-9ab4-04b8539a375a)

Several approaches were explored to add `{gene}_coverage` columns during ingest workflow (as opposed to during phylogenetic workflow). The different approaches were summarized by @joverlee521 and @jameshadfield and copied here for context of this PR, along with added comments from @j23414 in **\[comments\]**: 

1. Generalize RSV's [extend-metadata](https://github.com/nextstrain/rsv/blob/8eaf4cf8bbc67f267569881790d908c5719ae1aa/ingest/bin/extend-metadata.py) to take gene coordinates as input to calculate gene coverage. This will require gene coordinates to be maintained in the config YAML. Follow current pattern of outputing gene coverage columns that can be used for filter **\[ Opened an issue: https://github.com/nextstrain/rsv/issues/57 ~ @j23414 \]**
2. Use Nextclade's failedCdses column to determine if E gene has coverage. Outputs E gene included with True/False that can be used for filter. **\[I went ahead and appended the failedCdses column from Nextclade, so we can still use this method for other genes ~ @j23414 \]**
3. We briefly talked about whether it would be possible for Nextclade to output {CDS}_coverage columns in addition to the full genome coverage column. This will allow the workflow to use the Nextclade columns for filter without having to maintain the gene coordinates or parse the dataset GFF file to get the coordinates
4. Use the output (translated) CDS alignments from nextclade to add columns to the metadata with amino acid length or similar. This could then be used via augur filter --query .... This approach would be made obsolete by (3), but it's pretty easy to do right now. I **\[@jameshadfield\]**  think it's preferable to (1) in both the case of compound CDSs and the case where a genome alignment extends both sides of the CDS but actually has very little coverage over the CDS itself. **\[This PR is following approach 4 ~ @j23414 \]**

## New Metadata

To view the new "E_coverage" columns, feel free to download the new metadata at:

```bash
wget https://data.nextstrain.org/files/workflows/dengue/metadata_all.tsv.zst
zstd -d metadata_all.tsv.zst 
```

The new {gene}_coverage columns are the rightmost columns.

## Related issue(s)

* General Issue: https://github.com/nextstrain/private/issues/102#issuecomment-2010616347
* More specific Issue: https://github.com/nextstrain/dengue/issues/17
* Other attempt to solve specific issue: https://github.com/nextstrain/dengue/pull/18
* Related PR in RSV: https://github.com/nextstrain/rsv/pull/55
* Related issue in Measles: https://github.com/nextstrain/measles/issues/13

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
