### PR TITLE
Add nextstrain-automation build-configs to phylogenetic worklfow

### DIFF
--- a/phylogenetic/README.md
+++ b/phylogenetic/README.md
@@ -69,3 +69,17 @@ With access to AWS, this can be more quickly run as:
 [auspice]: https://docs.nextstrain.org/projects/auspice/en/stable/index.html
 [Installing Nextstrain guide]: https://docs.nextstrain.org/en/latest/install.html
 [Running a Pathogen Workflow guide]: https://docs.nextstrain.org/en/latest/tutorials/running-a-workflow.html
+
+### Deploying build
+
+To run the workflow and automatically deploy the build to nextstrain.org,
+you will need to have AWS credentials to run the following:
+
+```
+nextstrain build \
+    --env AWS_ACCESS_KEY_ID \
+    --env AWS_SECRET_ACCESS_KEY \
+    . \
+        deploy_all \
+        --configfile build-configs/nextstrain-automation/config.yaml
+```

--- a/phylogenetic/README.md
+++ b/phylogenetic/README.md
@@ -27,9 +27,10 @@ Once you've run the build, you can view the results in auspice:
 
 ## Configuration
 
-Configuration takes place entirely with the `Snakefile`. This can be read top-to-bottom, each rule
-specifies its file inputs and output and also its parameters. There is little redirection and each
-rule should be able to be reasoned with on its own.
+Configuration for the workflow takes place entirely within the [defaults/config_dengue.ymal](defaults/config_dengue.yaml).
+The analysis pipeline is contained in [Snakefile](Snakefile) with included [rules](rules).
+Each rule specifies its file inputs and output and pulls its parameters from the config.
+There is little redirection and each rule should be able to be reasoned with on its own.
 
 
 ### Using GenBank data

--- a/phylogenetic/build-configs/nextstrain-automation/config.yaml
+++ b/phylogenetic/build-configs/nextstrain-automation/config.yaml
@@ -1,0 +1,4 @@
+custom_rules:
+  - build-configs/nextstrain-automation/deploy.smk
+
+deploy_url: "s3://nextstrain-data"

--- a/phylogenetic/build-configs/nextstrain-automation/deploy.smk
+++ b/phylogenetic/build-configs/nextstrain-automation/deploy.smk
@@ -1,0 +1,15 @@
+"""
+This part of the workflow handles automatic deployments of the zika build.
+Uploads the build defined as the default output of the workflow through
+the `all` rule from Snakefille
+"""
+
+rule deploy_all:
+    input: *rules.all.input
+    output: touch("results/deploy_all.done")
+    params:
+        deploy_url = config["deploy_url"]
+    shell:
+        """
+        nextstrain remote upload {params.deploy_url} {input}
+        """


### PR DESCRIPTION
## Description of proposed changes

Adds a custom config and rules for deploying the final Auspice dataset of the phylogenetic workflow.

From [slack](https://bedfordlab.slack.com/archives/C01LCTT7JNN/p1711499690732839?thread_ts=1711066498.238259&cid=C01LCTT7JNN), had permission to duplicate changes from https://github.com/nextstrain/zika/pull/51

## Related issue(s)

* Tried to exactly duplicate: https://github.com/nextstrain/zika/pull/51

## Checklist

- [ ] Checks pass

