### PR TITLE
Automate ingest and phylogenetic workflows

### DIFF
--- a/.github/workflows/ingest-to-phylogenetic.yaml
+++ b/.github/workflows/ingest-to-phylogenetic.yaml
@@ -1,0 +1,40 @@
+name: Ingest to phylogenetic
+
+defaults:
+  run:
+    # This is the same as GitHub Action's `bash` keyword as of 20 June 2023:
+    # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsshell
+    #
+    # Completely spelling it out here so that GitHub can't change it out from under us
+    # and we don't have to refer to the docs to know the expected behavior.
+    shell: bash --noprofile --norc -eo pipefail {0}
+
+on:
+  workflow_dispatch:
+
+jobs:
+  ingest:
+    permissions:
+      id-token: write
+    uses: nextstrain/.github/.github/workflows/pathogen-repo-build.yaml@master
+    secrets: inherit
+    with:
+      # Starting with the default docker runtime
+      # We can migrate to AWS Batch when/if we need to for more resources or if
+      # the job runs longer than the GH Action limit of 6 hours.
+      runtime: docker
+      run: |
+        nextstrain build \
+          --env AWS_ACCESS_KEY_ID \
+          --env AWS_SECRET_ACCESS_KEY \
+          ingest \
+            upload_all \
+            --configfile build-configs/nextstrain-automation/config.yaml
+      # Specifying artifact name to differentiate ingest build outputs from
+      # the phylogenetic build outputs
+      artifact-name: ingest-build-output
+      artifact-paths: |
+        ingest/results/
+        ingest/benchmarks/
+        ingest/logs/
+        ingest/.snakemake/log/

--- a/.github/workflows/ingest-to-phylogenetic.yaml
+++ b/.github/workflows/ingest-to-phylogenetic.yaml
@@ -11,6 +11,13 @@ defaults:
 
 on:
   workflow_dispatch:
+    inputs:
+      ingest_image:
+        description: 'Specific container image to use for ingest workflow (will override the default of "nextstrain build")'
+        required: false
+      phylogenetic_image:
+        description: 'Specific container image to use for phylogenetic workflow (will override the default of "nextstrain build")'
+        required: false
 
 jobs:
   ingest:
@@ -23,6 +30,8 @@ jobs:
       # We can migrate to AWS Batch when/if we need to for more resources or if
       # the job runs longer than the GH Action limit of 6 hours.
       runtime: docker
+      env: |
+        NEXTSTRAIN_DOCKER_IMAGE: ${{ inputs.ingest_image }}
       run: |
         nextstrain build \
           --env AWS_ACCESS_KEY_ID \
@@ -91,6 +100,8 @@ jobs:
       # We can migrate to AWS Batch when/if we need to for more resources or if
       # the job runs longer than the GH Action limit of 6 hours.
       runtime: docker
+      env: |
+        NEXTSTRAIN_DOCKER_IMAGE: ${{ inputs.phylogenetic_image }}
       run: |
         nextstrain build \
           --env AWS_ACCESS_KEY_ID \

--- a/.github/workflows/ingest-to-phylogenetic.yaml
+++ b/.github/workflows/ingest-to-phylogenetic.yaml
@@ -38,3 +38,34 @@ jobs:
         ingest/benchmarks/
         ingest/logs/
         ingest/.snakemake/log/
+
+  # TKTK check if ingest results include new data
+  # potentially use actions/cache to store Metadata.sha256sum of S3 files
+
+  phylogenetic:
+    needs: [ingest]
+    permissions:
+      id-token: write
+    uses: nextstrain/.github/.github/workflows/pathogen-repo-build.yaml@master
+    secrets: inherit
+    with:
+      # Starting with the default docker runtime
+      # We can migrate to AWS Batch when/if we need to for more resources or if
+      # the job runs longer than the GH Action limit of 6 hours.
+      runtime: docker
+      run: |
+        nextstrain build \
+          --env AWS_ACCESS_KEY_ID \
+          --env AWS_SECRET_ACCESS_KEY \
+          phylogenetic \
+            deploy_all \
+            --configfile build-configs/nextstrain-automation/config.yaml
+      # Specifying artifact name to differentiate ingest build outputs from
+      # the phylogenetic build outputs
+      artifact-name: phylogenetic-build-output
+      artifact-paths: |
+        phylogenetic/auspice/
+        phylogenetic/results/
+        phylogenetic/benchmarks/
+        phylogenetic/logs/
+        phylogenetic/.snakemake/log/

--- a/.github/workflows/ingest-to-phylogenetic.yaml
+++ b/.github/workflows/ingest-to-phylogenetic.yaml
@@ -96,7 +96,7 @@ jobs:
             key="${s3path#*/}"
 
             s3_hash="$(aws s3api head-object --no-sign-request --bucket "$bucket" --key "$key" --query Metadata.sha256sum --output text 2>/dev/null || echo "$no_hash")"
-            echo "${s3_hash}" >> ingest-output-sha256sum
+            echo "${s3_hash}" | tee -a ingest-output-sha256sum
           done
 
       - name: Check cache

--- a/.github/workflows/ingest-to-phylogenetic.yaml
+++ b/.github/workflows/ingest-to-phylogenetic.yaml
@@ -10,6 +10,25 @@ defaults:
     shell: bash --noprofile --norc -eo pipefail {0}
 
 on:
+  schedule:
+    # Note times are in UTC, which is 1 or 2 hours behind CET depending on daylight savings.
+    #
+    # Note the actual runs might be late.
+    # Numerous people were confused, about that, including me:
+    #  - https://github.community/t/scheduled-action-running-consistently-late/138025/11
+    #  - https://github.com/github/docs/issues/3059
+    #
+    # Note, '*' is a special character in YAML, so you have to quote this string.
+    #
+    # Docs:
+    #  - https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#schedule
+    #
+    # Tool that deciphers this particular format of crontab string:
+    #  - https://crontab.guru/
+    #
+    # Runs at 4pm UTC (12pm EDT) since curation by NCBI happens on the East Coast.
+    - cron: '0 16 * * *'
+
   workflow_dispatch:
     inputs:
       ingest_image:

--- a/.github/workflows/ingest-to-phylogenetic.yaml
+++ b/.github/workflows/ingest-to-phylogenetic.yaml
@@ -79,6 +79,8 @@ jobs:
     steps:
       - name: Get sha256sum
         id: get-sha256sum
+        env:
+          AWS_DEFAULT_REGION: ${{ vars.AWS_DEFAULT_REGION }}
         run: |
           s3_urls=(
             "s3://nextstrain-data/files/workflows/dengue/metadata_all.tsv.zst"

--- a/.github/workflows/ingest-to-phylogenetic.yaml
+++ b/.github/workflows/ingest-to-phylogenetic.yaml
@@ -39,11 +39,49 @@ jobs:
         ingest/logs/
         ingest/.snakemake/log/
 
-  # TKTK check if ingest results include new data
-  # potentially use actions/cache to store Metadata.sha256sum of S3 files
+  # Check if ingest results include new data by checking for the cache
+  # of the file with the results' Metadata.sh256sum (which should have been added within upload-to-s3)
+  # GitHub will remove any cache entries that have not been accessed in over 7 days,
+  # so if the workflow has not been run over 7 days then it will trigger phylogenetic.
+  check-new-data:
+    needs: [ingest]
+    runs-on: ubuntu-latest
+    outputs:
+      cache-hit: ${{ steps.check-cache.outputs.cache-hit }}
+    steps:
+      - name: Get sha256sum
+        id: get-sha256sum
+        run: |
+          s3_urls=(
+            "s3://nextstrain-data/files/workflows/dengue/metadata_all.tsv.zst"
+            "s3://nextstrain-data/files/workflows/dengue/sequences_all.fasta.zst"
+          )
+
+          # Code below is modified from ingest/upload-to-s3
+          # https://github.com/nextstrain/ingest/blob/c0b4c6bb5e6ccbba86374d2c09b42077768aac23/upload-to-s3#L23-L29
+
+          no_hash=0000000000000000000000000000000000000000000000000000000000000000
+
+          for s3_url in "${s3_urls[@]}"; do
+            s3path="${s3_url#s3://}"
+            bucket="${s3path%%/*}"
+            key="${s3path#*/}"
+
+            s3_hash="$(aws s3api head-object --no-sign-request --bucket "$bucket" --key "$key" --query Metadata.sha256sum --output text 2>/dev/null || echo "$no_hash")"
+            echo "${s3_hash}" >> ingest-output-sha256sum
+          done
+
+      - name: Check cache
+        id: check-cache
+        uses: actions/cache@v4
+        with:
+          path: ingest-output-sha256sum
+          key: ingest-output-sha256sum-${{ hashFiles('ingest-output-sha256sum') }}
+          lookup-only: true
 
   phylogenetic:
-    needs: [ingest]
+    needs: [check-new-data]
+    if: ${{ needs.check-new-data.outputs.cache-hit != 'true' }}
     permissions:
       id-token: write
     uses: nextstrain/.github/.github/workflows/pathogen-repo-build.yaml@master

--- a/ingest/build-configs/nextstrain-automation/upload.smk
+++ b/ingest/build-configs/nextstrain-automation/upload.smk
@@ -19,7 +19,7 @@ rule upload_to_s3:
     output:
         "results/upload/{remote_file}.upload",
     params:
-        quiet="" if send_notifications else "--quiet",
+        quiet="--quiet",
         s3_dst=config["s3_dst"],
         cloudfront_domain=config["cloudfront_domain"],
     shell:

--- a/phylogenetic/Snakefile
+++ b/phylogenetic/Snakefile
@@ -4,7 +4,7 @@ serotypes = ['all', 'denv1', 'denv2', 'denv3', 'denv4']
 
 rule all:
     input:
-        auspice_json = expand("auspice/dengue_{serotype}.json", serotype=serotypes)
+        auspice_json = expand("auspice/dengue_{serotype}_genome.json", serotype=serotypes)
 
 include: "rules/prepare_sequences.smk"
 include: "rules/construct_phylogeny.smk"

--- a/phylogenetic/rules/export.smk
+++ b/phylogenetic/rules/export.smk
@@ -51,8 +51,8 @@ rule final_strain_name:
         metadata="data/metadata_{serotype}.tsv",
         root_sequence="results/raw_dengue_{serotype}_root-sequence.json",
     output:
-        auspice_json="auspice/dengue_{serotype}.json",
-        root_sequence="auspice/dengue_{serotype}_root-sequence.json",
+        auspice_json="auspice/dengue_{serotype}_genome.json",
+        root_sequence="auspice/dengue_{serotype}_genome_root-sequence.json",
     params:
         strain_id=config.get("strain_id_field", "strain"),
         display_strain_field=config.get("display_strain_field", "strain"),


### PR DESCRIPTION
## Description of proposed changes

Coordinated with @joverlee521 to copy commits from zika PR: https://github.com/nextstrain/zika/pull/52

Adds a single GH Action workflow to automate the ingest and phylogenetic workflows, set to run daily at the same time as the [automated mpox ingest](https://github.com/nextstrain/mpox/blob/e439235ff1c1d66e7285b774e9536e2896d9cd2f/.github/workflows/fetch-and-ingest.yaml#L4-L21). 

Uses GH Action caches to store hash of ingest results' `Metadata.sha256sum` values [added to the S3 metadata within upload-to-s3](https://github.com/nextstrain/ingest/blob/c0b4c6bb5e6ccbba86374d2c09b42077768aac23/upload-to-s3#L44). If the cache contains a match from previous runs of the GH Action workflow, then the workflow will skip the phylogenetic job. 

See commits for details.

## Related issue(s)

Based on discussion in https://github.com/nextstrain/pathogen-repo-guide/issues/25
* https://github.com/nextstrain/zika/pull/52

## Checklist

- [x] Checks pass
- [x] Manually trigger [first full run](https://github.com/nextstrain/dengue/actions/runs/8573689543/job/23499648464)

The manual run completed successfully although does not push to the live site since output files do not have "_genome" postfixs in the filenames:

```
nextstrain remote upload s3://nextstrain-data auspice/dengue_all.json auspice/dengue_denv1.json auspice/dengue_denv2.json auspice/dengue_denv3.json auspice/dengue_denv4.json
        
Uploading auspice/dengue_all.json as dengue_all.json
Uploading auspice/dengue_denv1.json as dengue_denv1.json
Uploading auspice/dengue_denv2.json as dengue_denv2.json
Uploading auspice/dengue_denv3.json as dengue_denv3.json
Uploading auspice/dengue_denv4.json as dengue_denv4.json
```


