### PR TITLE
phylogenetic: Use inline root sequence

### DIFF
--- a/phylogenetic/rules/export.smk
+++ b/phylogenetic/rules/export.smk
@@ -29,8 +29,7 @@ rule export:
         aa_muts = "results/aa-muts_{serotype}.json",
         auspice_config = "config/auspice_config_{serotype}.json",
     output:
-        auspice_json = "results/raw_dengue_{serotype}.json",
-        root_sequence = "results/raw_dengue_{serotype}_root-sequence.json",
+        auspice_json = "results/raw_dengue_{serotype}.json"
     params:
         strain_id = config.get("strain_id_field", "strain"),
     shell:
@@ -41,7 +40,7 @@ rule export:
             --metadata-id-columns {params.strain_id} \
             --node-data {input.branch_lengths} {input.traits} {input.clades} {input.nt_muts} {input.aa_muts} \
             --auspice-config {input.auspice_config} \
-            --include-root-sequence \
+            --include-root-sequence-inline \
             --output {output.auspice_json}
         """
 
@@ -49,10 +48,8 @@ rule final_strain_name:
     input:
         auspice_json="results/raw_dengue_{serotype}.json",
         metadata="data/metadata_{serotype}.tsv",
-        root_sequence="results/raw_dengue_{serotype}_root-sequence.json",
     output:
-        auspice_json="auspice/dengue_{serotype}_genome.json",
-        root_sequence="auspice/dengue_{serotype}_genome_root-sequence.json",
+        auspice_json="auspice/dengue_{serotype}_genome.json"
     params:
         strain_id=config.get("strain_id_field", "strain"),
         display_strain_field=config.get("display_strain_field", "strain"),
@@ -64,5 +61,4 @@ rule final_strain_name:
             --input-auspice-json {input.auspice_json} \
             --display-strain-name {params.display_strain_field} \
             --output {output.auspice_json}
-        cp {input.root_sequence} {output.root_sequence}
         """


### PR DESCRIPTION
## Description of proposed changes
~Explicitly state that the root-sequence.json file is an expected output of the core phylogenetic workflow.~

~This also ensures that the Nextstrain automation rule `deploy_all` will include the root-sequence.json in the upload.~

Based on feedback from @jameshadfield in
https://github.com/nextstrain/zika/pull/56#issuecomment-2058060422

Looking at the existing dataset files on S3,
the 5-6 KiB root-sequence.jsons are pretty negligible when the main
Auspice JSONs are 600-800 KiB. Nextstrain datasets are limited by the
500MB memory cap in Chrome,¹ so we'd be fine adding the
root sequence inline.

This ensures that our uploads will include the root sequence so that
they don't get out-of-sync with the main Auspice JSON.

¹ https://github.com/nextstrain/auspice/issues/1622

## Related issue(s)

Follow up to https://github.com/nextstrain/dengue/pull/37
Similar to https://github.com/nextstrain/zika/pull/56

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
