### PR TITLE
Instead of '?', set default gene_coverage to 0

### DIFF
--- a/ingest/rules/nextclade.smk
+++ b/ingest/rules/nextclade.smk
@@ -147,7 +147,7 @@ rule append_gene_coverage_columns:
                 --filter-file $FILE \
                 --key-fields {params.id_field} \
                 --append-fields '*_coverage' \
-                --write-all ? \
+                --write-all 0 \
                 {output.metadata_all} \
             > results/temp_aggregate_gene_coverage.tsv
             mv results/temp_aggregate_gene_coverage.tsv {output.metadata_all}


### PR DESCRIPTION
## Description of proposed changes

After discussion, it became clear that keeping `gene_coverage` columns a numeric value may simplify the subsequent augur filter command.

## Related issue(s)

* https://github.com/nextstrain/dengue/pull/18

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
