### PR TITLE
hotfix: display genbank accession link in node popup box

### DIFF
--- a/phylogenetic/rules/export.smk
+++ b/phylogenetic/rules/export.smk
@@ -96,6 +96,9 @@ rule prepare_auspice_config:
               "country",
               "region",
               "author"
+            ],
+            "metadata_columns": [
+              "genbank_accession"
             ]
           }
 


### PR DESCRIPTION
## Description of proposed changes

In the process of dynamically generating the auspice config files for PR https://github.com/nextstrain/dengue/pull/45, I missed incorporating the changes from https://github.com/nextstrain/dengue/pull/40/commits/9b9d1b2dc210a670a2b1588a830286ac3c9ea8b5, which ensures that the "genbank_accession" is displayed as a hyperlink in the node popup box

I'm [running a test build](https://github.com/nextstrain/dengue/actions/runs/8926755640) and will proceed with merging this PR if the issue is resolved in the final results, to be available at: 

* https://next.nextstrain.org/staging/dengue/trials/genbanklink20240502/dengue/denv1/genome 

## Related issue(s)

* Hotfix to https://github.com/nextstrain/dengue/pull/45

## Checklist

- [ ] Checks pass

