### PR TITLE
Add configurable staged input files for the `phylogenetic` github action

### DIFF
--- a/.github/workflows/phylogenetic.yaml
+++ b/.github/workflows/phylogenetic.yaml
@@ -32,13 +32,13 @@ on:
         type: string
       sequences_url:
         description: |
-          URL for a sequences.fasta.zst file.
+          URL for sequences_{serotype}.fasta.zst files where {serotype} will be replaced by all, denv1 to denv4.
           If not provided, will use default sequences_url from phylogenetic/config/config_dengue.yaml
         required: false
         type: string
       metadata_url:
         description: |
-          URL for a metadata.tsv.zst file.
+          URL for metadata_{serotype}.tsv.zst files where {serotype} will be replaced by all, denv1 to denv4.
           If not provided, will use default metadata_url from phylogenetic/config/config_dengue.yaml
         required: false
         type: string

--- a/phylogenetic/config/config_dengue.yaml
+++ b/phylogenetic/config/config_dengue.yaml
@@ -1,3 +1,9 @@
+# Sequences must be FASTA and metadata must be TSV
+# Both files must be zstd compressed
+# Both files must have a {serotype} expandable field to be replaced by all, denv1-denv4
+sequences_url: "https://data.nextstrain.org/files/workflows/dengue/sequences_{serotype}.fasta.zst"
+metadata_url: "https://data.nextstrain.org/files/workflows/dengue/metadata_{serotype}.tsv.zst"
+
 strain_id_field: "genbank_accession"
 display_strain_field: "strain"
 

--- a/phylogenetic/rules/prepare_sequences.smk
+++ b/phylogenetic/rules/prepare_sequences.smk
@@ -21,8 +21,8 @@ rule download:
         metadata = "data/metadata_{serotype}.tsv.zst"
 
     params:
-        sequences_url = "https://data.nextstrain.org/files/workflows/dengue/sequences_{serotype}.fasta.zst",
-        metadata_url = "https://data.nextstrain.org/files/workflows/dengue/metadata_{serotype}.tsv.zst"
+        sequences_url = config["sequences_url"],
+        metadata_url = config["metadata_url"],
     shell:
         """
         curl -fsSL --compressed {params.sequences_url:q} --output {output.sequences}


### PR DESCRIPTION
## Description of proposed changes

Fixes https://github.com/nextstrain/dengue/issues/49

## Related issue(s)

* https://github.com/nextstrain/dengue/issues/49
* Nice to have to test a future PR for https://github.com/nextstrain/dengue/compare/main...consistent-serotype-genotype-column-names
* which is addressing Issue: https://github.com/nextstrain/dengue/issues/41

## Checklist

- [x] Checks pass
- [x] GH test at https://github.com/nextstrain/dengue/actions/runs/9149432810

Serotype expanded as expected

```
rule download:
    output: data/sequences_denv3.fasta.zst, data/metadata_denv3.tsv.zst
    jobid: 86
    reason: Missing output files: data/sequences_denv3.fasta.zst, data/metadata_denv3.tsv.zst
    wildcards: serotype=denv3
    resources: tmpdir=/tmp
        curl -fsSL --compressed https://data.nextstrain.org/files/workflows/dengue/trials/serogeno20240518/sequences_denv3.fasta.zst --output data/sequences_denv3.fasta.zst
        curl -fsSL --compressed https://data.nextstrain.org/files/workflows/dengue/trials/serogeno20240518/metadata_denv3.tsv.zst --output data/metadata_denv3.tsv.zst
```
