### PR TITLE
Consistent serotype-genotype column names and auspice color titles

### DIFF
--- a/ingest/defaults/annotations.tsv
+++ b/ingest/defaults/annotations.tsv
@@ -2,1002 +2,1002 @@ KM204119	strain	Hawaii # from GenBank record, DENV1 WHO reference
 KM204118	strain	New_Guinea_C # from GenBank record, DENV2 WHO reference
 KU050695	strain	H87 # from GenBank record, DENV3 WHO reference
 KR011349	strain	H241 # from GenBank record, DENV4 WHO reference
-JF260983	ncbi_serotype	denv2 # denv2/S from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KT026309	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KT445955	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KT445956	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KT445957	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KT445958	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KT445959	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KT445960	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KT445961	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KT445962	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KT445963	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KX059015	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KX059016	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KX059017	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KX059019	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KX059021	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KX059022	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KX059024	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KX059025	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KX059028	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KX059029	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KX059030	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KX059033	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KX059037	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY369949	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY369950	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY369951	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586306	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586307	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586308	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586309	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586310	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586311	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586312	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586313	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586314	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586315	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586316	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586317	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586318	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586319	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586320	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586321	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586322	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586323	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586324	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586325	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586326	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586327	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586328	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586329	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586330	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586331	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586332	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586333	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586334	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586335	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586336	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586337	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586338	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586339	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586340	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586341	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586342	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586343	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586344	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586345	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586346	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586347	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586348	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586349	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586350	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586351	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586352	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586353	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586354	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586355	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586356	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586357	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586358	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586359	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586360	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586361	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586362	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586363	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586364	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586365	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586366	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586367	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586368	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586369	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586370	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586371	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586372	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586373	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586374	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586375	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586376	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586377	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586378	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586379	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586380	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586381	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586382	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586383	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586384	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586385	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586386	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586387	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586388	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586389	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586390	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586391	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586392	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586393	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586394	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586395	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586396	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586397	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586398	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586399	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586400	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586401	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586402	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586403	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586404	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586405	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586406	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586407	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586408	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586409	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586410	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586411	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586412	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586413	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586414	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586415	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586416	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586417	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586418	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586419	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586420	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586421	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586422	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586423	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586424	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586425	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586426	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586427	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586428	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586429	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586430	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586431	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586432	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586433	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586434	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586435	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586436	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586437	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586438	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586439	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586440	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586441	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586442	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586443	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586444	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586445	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586446	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586447	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586448	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586449	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586450	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586451	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586452	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586453	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586454	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586455	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586456	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586457	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586458	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586459	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586460	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586461	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586462	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586463	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586464	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586465	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586466	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586467	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586468	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586469	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586470	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586471	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586472	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586473	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586474	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586475	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586476	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586477	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586478	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586479	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586480	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586481	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586482	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586483	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586484	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586485	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586486	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586487	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586488	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586489	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586490	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586491	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586492	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586493	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586494	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586495	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586496	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586497	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586498	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586499	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586500	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586501	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586502	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586503	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586504	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586505	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586506	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586507	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586508	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586509	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586510	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586511	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586512	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586513	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586514	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586515	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586516	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586517	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586518	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586519	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586520	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586521	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586522	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586523	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586524	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586525	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586526	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586527	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586528	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586529	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586530	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586531	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586532	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586533	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586534	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586535	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586536	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586537	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586538	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586539	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586540	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586541	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586542	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586543	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586544	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586545	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586546	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KY586547	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586548	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586549	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586550	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586551	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586552	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586553	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586554	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586555	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586556	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586557	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586558	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586559	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586560	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586561	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586562	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586563	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586564	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586565	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586566	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586567	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586568	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586569	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586570	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586571	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586572	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586573	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586574	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586575	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586576	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586577	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586578	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586579	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586580	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586581	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586582	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586583	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586584	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586585	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586586	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586587	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586588	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586589	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586590	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586591	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586592	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586593	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586594	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586595	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586596	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586597	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586598	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586599	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586600	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586601	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586602	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586603	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586604	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586605	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586606	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586607	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586608	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586609	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586610	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586611	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586612	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586613	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586614	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586615	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586616	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586617	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586618	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586619	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586620	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586621	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586622	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586623	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586624	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586625	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586626	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586627	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586628	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586629	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586630	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586631	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586632	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586633	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586634	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586635	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586636	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586637	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586638	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586639	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586640	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586641	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586642	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586643	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586644	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586645	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586646	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586647	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586648	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586649	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586650	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586651	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586652	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586653	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586654	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586655	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586656	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586657	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586658	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586659	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586660	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586661	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586662	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586663	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586664	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586665	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586666	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586667	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586668	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586669	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586670	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586671	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586672	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586673	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586674	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586675	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586676	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586677	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586678	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586679	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586680	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586681	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586682	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586683	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586684	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586685	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586686	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586687	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586688	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586689	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586690	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586691	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586692	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586693	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586694	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586695	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586696	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586697	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586698	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586699	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586700	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-KY586701	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586702	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586703	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586704	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586705	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586706	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586707	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586708	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586709	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586710	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586711	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586712	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586713	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586714	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586715	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586716	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586717	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586718	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586719	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586720	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586721	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586722	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586723	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586724	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586725	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586726	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586727	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586728	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586729	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586730	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586731	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586732	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586733	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586734	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586735	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586736	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586737	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586738	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586739	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586740	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586741	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586742	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586743	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586744	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586745	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586746	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586747	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586748	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586749	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586750	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586751	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586752	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586753	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586754	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586755	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586756	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586757	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586758	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586759	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586760	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586761	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586762	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586763	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586764	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586765	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586766	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586767	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586768	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586769	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586770	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586771	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586772	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586773	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586774	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586775	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586776	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586777	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586778	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586779	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586780	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586781	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586782	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586783	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586784	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586785	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586786	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586787	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586788	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586789	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586790	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586791	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586792	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586793	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586794	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586795	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586796	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586797	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586798	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586799	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586800	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586801	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586802	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586803	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586804	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586805	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586806	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586807	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586808	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586809	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586810	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586811	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586812	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586813	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586814	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586815	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586816	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586817	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586818	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586819	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586820	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586821	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586822	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-KY586823	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586824	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586825	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586826	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586840	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586841	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586842	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586843	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586844	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586845	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586846	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586847	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586848	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586849	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586850	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586851	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586852	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586853	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586854	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586855	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586856	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586857	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586858	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586859	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586860	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586861	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586862	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586863	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586864	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586865	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586866	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586867	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586868	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586869	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586870	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586871	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586872	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586873	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586874	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586875	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586876	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586877	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586878	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586879	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586880	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586881	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586882	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586883	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586884	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586885	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586886	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586887	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586888	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586889	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586890	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586891	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586892	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586893	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586894	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586895	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586896	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586897	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586899	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586900	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586901	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586902	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586905	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586906	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586907	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586911	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586913	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586915	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586916	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586920	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586921	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586923	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586924	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586925	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586926	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586927	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586928	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586929	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586930	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586931	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586933	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586934	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586936	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586937	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586941	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586942	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586943	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586944	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586945	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586946	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY977454	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-MG599592	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-MG599593	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-MG599594	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-MG599595	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-MG599596	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-MG599597	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-MG599598	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-MG599599	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-MG599600	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-MG599601	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-MG599602	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-MG599603	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-MG599604	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-MG599605	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-MG599606	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-MG599607	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-MG599608	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-MG599609	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-MG599610	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-MG599611	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-MG599612	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-MG599613	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-MG599614	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-MG599615	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-MG599616	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-MG599617	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-MG599618	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-MG599619	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-MG599620	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-MG599621	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-MG599622	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-MG599623	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-MG599624	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-MG599625	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-MG599626	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-MG599627	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-MG599628	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-MG599629	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-MG599630	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-MG599631	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-MG599632	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-MG599633	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-MG599634	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-MH450295	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-MH450296	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-MH450297	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-MH450298	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-MH450299	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-MH450300	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-MH450301	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-MH450302	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-MH450303	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-MH450304	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-MH450305	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-MH450306	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-MH450307	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-MH450308	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-MH450309	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-MH450310	ncbi_serotype	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
-MH450311	ncbi_serotype	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
-MN567692	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-MN567693	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-MN567694	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-MN567695	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-MN567696	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-MN567697	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KF907503	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KT026308	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KT026310	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KX059018	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KX059020	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KX059023	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KX059026	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KX059027	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KX059031	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KX059032	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KX059034	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KX059035	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KX059036	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KX812530	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586827	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586828	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586829	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586830	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586831	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586832	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586833	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586834	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586835	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586836	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586837	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586838	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586839	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586898	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586903	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586904	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586908	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586909	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586910	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586912	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586914	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586917	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586918	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586919	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586922	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586932	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586935	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586938	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586939	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KY586940	ncbi_serotype	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
-KP772252	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KR052012	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KR071622	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KR919820	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-KR919821	ncbi_serotype	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
-ON127553	ncbi_serotype	denv3 # Annotated as denv1 but aligns closer to denv3
-ON127551	ncbi_serotype	denv3 # Annotated as denv1 but aligns closer to denv3
-ON127538	ncbi_serotype	denv3 # Annotated as denv1 but aligns closer to denv3
-ON127534	ncbi_serotype	denv3 # Annotated as denv1 but aligns closer to denv3
-ON127419	ncbi_serotype	denv3 # Annotated as denv1 but aligns closer to denv3
-ON116130	ncbi_serotype	denv3 # Annotated as denv1 but aligns closer to denv3
-ON115819	ncbi_serotype	denv3 # Annotated as denv1 but aligns closer to denv3
-ON115817	ncbi_serotype	denv3 # Annotated as denv1 but aligns closer to denv3
-ON115815	ncbi_serotype	denv3 # Annotated as denv1 but aligns closer to denv3
-ON115812	ncbi_serotype	denv3 # Annotated as denv1 but aligns closer to denv3
-ON115183	ncbi_serotype	denv3 # Annotated as denv1 but aligns closer to denv3
-ON115030	ncbi_serotype	denv3 # Annotated as denv1 but aligns closer to denv3
-ON115026	ncbi_serotype	denv3 # Annotated as denv1 but aligns closer to denv3
-ON115024	ncbi_serotype	denv3 # Annotated as denv1 but aligns closer to denv3
-ON115022	ncbi_serotype	denv3 # Annotated as denv1 but aligns closer to denv3
-ON111446	ncbi_serotype	denv3 # Annotated as denv1 but aligns closer to denv3
-ON103391	ncbi_serotype	denv3 # Annotated as denv1 but aligns closer to denv3
-ON103303	ncbi_serotype	denv3 # Annotated as denv1 but aligns closer to denv3
-OK079104	ncbi_serotype	denv3 # Annotated as denv1 but aligns closer to denv3
-ON046278	ncbi_serotype	denv2 # Annotated as denv1 but aligns closer to denv2
-ON046277	ncbi_serotype	denv2 # Annotated as denv1 but aligns closer to denv2
-ON046276	ncbi_serotype	denv2 # Annotated as denv1 but aligns closer to denv2
-ON046275	ncbi_serotype	denv2 # Annotated as denv1 but aligns closer to denv2
-ON046274	ncbi_serotype	denv2 # Annotated as denv1 but aligns closer to denv2
-ON046273	ncbi_serotype	denv2 # Annotated as denv1 but aligns closer to denv2
-ON046272	ncbi_serotype	denv2 # Annotated as denv1 but aligns closer to denv2
-ON046271	ncbi_serotype	denv2 # Annotated as denv1 but aligns closer to denv2
-ON046270	ncbi_serotype	denv2 # Annotated as denv1 but aligns closer to denv2
-ON046269	ncbi_serotype	denv2 # Annotated as denv1 but aligns closer to denv2
-ON046268	ncbi_serotype	denv2 # Annotated as denv1 but aligns closer to denv2
-ON045733	ncbi_serotype	denv4 # Annotated as denv1 but aligns closer to denv4
-S44168	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-OQ520876	ncbi_serotype	denv3 # Annotated as denv1 but matches denv3
-OQ520875	ncbi_serotype	denv3 # Annotated as denv1 but matches denv3
-OQ520874	ncbi_serotype	denv3 # Annotated as denv1 but matches denv3
-OQ520873	ncbi_serotype	denv3 # Annotated as denv1 but matches denv3
-OQ520872	ncbi_serotype	denv3 # Annotated as denv1 but matches denv3
-OQ519670	ncbi_serotype	denv3 # Annotated as denv1 but matches denv3
-OQ519669	ncbi_serotype	denv3 # Annotated as denv1 but matches denv3
-OQ519668	ncbi_serotype	denv3 # Annotated as denv1 but matches denv3
-OQ519667	ncbi_serotype	denv3 # Annotated as denv1 but matches denv3
-OQ519666	ncbi_serotype	denv3 # Annotated as denv1 but matches denv3
-OQ519665	ncbi_serotype	denv3 # Annotated as denv1 but matches denv3
-OQ519664	ncbi_serotype	denv3 # Annotated as denv1 but matches denv3
-OQ519663	ncbi_serotype	denv3 # Annotated as denv1 but matches denv3
-OQ519662	ncbi_serotype	denv3 # Annotated as denv1 but matches denv3
-OQ519661	ncbi_serotype	denv3 # Annotated as denv1 but matches denv3
-OQ519660	ncbi_serotype	denv3 # Annotated as denv1 but matches denv3
-OQ519659	ncbi_serotype	denv3 # Annotated as denv1 but matches denv3
-OQ519658	ncbi_serotype	denv3 # Annotated as denv1 but matches denv3
-OQ519657	ncbi_serotype	denv3 # Annotated as denv1 but matches denv3
-OQ519656	ncbi_serotype	denv3 # Annotated as denv1 but matches denv3
-OQ519655	ncbi_serotype	denv3 # Annotated as denv1 but matches denv3
-OQ519654	ncbi_serotype	denv3 # Annotated as denv1 but matches denv3
-OP788175	ncbi_serotype	denv4 # Annotated as denv1 but matches denv4
-OP788174	ncbi_serotype	denv4 # Annotated as denv1 but matches denv4
-OP788173	ncbi_serotype	denv4 # Annotated as denv1 but matches denv4
-OP788172	ncbi_serotype	denv4 # Annotated as denv1 but matches denv4
-OP788171	ncbi_serotype	denv4 # Annotated as denv1 but matches denv4
-OP788170	ncbi_serotype	denv4 # Annotated as denv1 but matches denv4
-OP788169	ncbi_serotype	denv4 # Annotated as denv1 but matches denv4
-OP788168	ncbi_serotype	denv4 # Annotated as denv1 but matches denv4
-OP788167	ncbi_serotype	denv4 # Annotated as denv1 but matches denv4
-OP788166	ncbi_serotype	denv4 # Annotated as denv1 but matches denv4
-OP788165	ncbi_serotype	denv4 # Annotated as denv1 but matches denv4
-OP788164	ncbi_serotype	denv4 # Annotated as denv1 but matches denv4
-OP788163	ncbi_serotype	denv4 # Annotated as denv1 but matches denv4
-OP788162	ncbi_serotype	denv4 # Annotated as denv1 but matches denv4
-OP788161	ncbi_serotype	denv4 # Annotated as denv1 but matches denv4
-OP788160	ncbi_serotype	denv4 # Annotated as denv1 but matches denv4
-OP788159	ncbi_serotype	denv4 # Annotated as denv1 but matches denv4
-OP788158	ncbi_serotype	denv4 # Annotated as denv1 but matches denv4
-OP788157	ncbi_serotype	denv4 # Annotated as denv1 but matches denv4
-OP788156	ncbi_serotype	denv4 # Annotated as denv1 but matches denv4
-OP788155	ncbi_serotype	denv4 # Annotated as denv1 but matches denv4
-OP788154	ncbi_serotype	denv4 # Annotated as denv1 but matches denv4
-OP788153	ncbi_serotype	denv4 # Annotated as denv1 but matches denv4
-OP788152	ncbi_serotype	denv4 # Annotated as denv1 but matches denv4
-OP788151	ncbi_serotype	denv4 # Annotated as denv1 but matches denv4
-OP788150	ncbi_serotype	denv4 # Annotated as denv1 but matches denv4
-OP788149	ncbi_serotype	denv4 # Annotated as denv1 but matches denv4
-OP788148	ncbi_serotype	denv4 # Annotated as denv1 but matches denv4
-OP788147	ncbi_serotype	denv4 # Annotated as denv1 but matches denv4
-OP788146	ncbi_serotype	denv4 # Annotated as denv1 but matches denv4
-OP788145	ncbi_serotype	denv4 # Annotated as denv1 but matches denv4
-OP788144	ncbi_serotype	denv4 # Annotated as denv1 but matches denv4
-OP788143	ncbi_serotype	denv4 # Annotated as denv1 but matches denv4
-OP788142	ncbi_serotype	denv4 # Annotated as denv1 but matches denv4
-OP788141	ncbi_serotype	denv4 # Annotated as denv1 but matches denv4
-OP788140	ncbi_serotype	denv4 # Annotated as denv1 but matches denv4
-OP788139	ncbi_serotype	denv4 # Annotated as denv1 but matches denv4
-OP788138	ncbi_serotype	denv4 # Annotated as denv1 but matches denv4
-OP788137	ncbi_serotype	denv4 # Annotated as denv1 but matches denv4
-OP741244	ncbi_serotype	denv3 # Annotated as denv1 but matches denv3
-OP741243	ncbi_serotype	denv3 # Annotated as denv1 but matches denv3
-OP740753	ncbi_serotype	denv3 # Annotated as denv1 but matches denv3
-OP491597	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-OP491531	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-OP491529	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-OP491465	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-OP435268	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-OP164424	ncbi_serotype	denv3 # Annotated as denv1 but matches denv3
-OP164423	ncbi_serotype	denv3 # Annotated as denv1 but matches denv3
-OP164422	ncbi_serotype	denv3 # Annotated as denv1 but matches denv3
-OP120949	ncbi_serotype	denv4 # Annotated as denv1 but matches denv4
-OP120948	ncbi_serotype	denv4 # Annotated as denv1 but matches denv4
-OP120947	ncbi_serotype	denv4 # Annotated as denv1 but matches denv4
-OP090329	ncbi_serotype	denv3 # Annotated as denv1 but matches denv3
-OP090328	ncbi_serotype	denv3 # Annotated as denv1 but matches denv3
-OP090327	ncbi_serotype	denv3 # Annotated as denv1 but matches denv3
-ON629748	ncbi_serotype	denv4 # Annotated as denv1 but matches denv4
-MZ278208	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-MW830396	ncbi_serotype	denv4 # Annotated as denv1 but matches denv4
-MW795722	ncbi_serotype	denv4 # Annotated as denv1 but matches denv4
-MW795721	ncbi_serotype	denv4 # Annotated as denv1 but matches denv4
-MW600550	ncbi_serotype	denv4 # Annotated as denv1 but matches denv4
-MW600549	ncbi_serotype	denv4 # Annotated as denv1 but matches denv4
-MW600548	ncbi_serotype	denv4 # Annotated as denv1 but matches denv4
-MW600547	ncbi_serotype	denv4 # Annotated as denv1 but matches denv4
-MW600546	ncbi_serotype	denv4 # Annotated as denv1 but matches denv4
-MW600545	ncbi_serotype	denv4 # Annotated as denv1 but matches denv4
-MW600544	ncbi_serotype	denv4 # Annotated as denv1 but matches denv4
-MW600543	ncbi_serotype	denv4 # Annotated as denv1 but matches denv4
-MW600542	ncbi_serotype	denv4 # Annotated as denv1 but matches denv4
-MW600541	ncbi_serotype	denv4 # Annotated as denv1 but matches denv4
-MW332625	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-MW332624	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-MW332618	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-MW332617	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-MW332592	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-MW332591	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-MW332590	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-MW332589	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-MW332588	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-MW332587	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-MW332586	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-MW332585	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-MW332584	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-MW332583	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-MW332582	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-MW332581	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-MW332580	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-MW332579	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-MW332578	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-MW332577	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-MW332576	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-MW332575	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-MW332509	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-MW332508	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-MW332507	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-MW332506	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-MW332505	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-MW332501	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-MW332500	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-MW332499	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-MW332498	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-MW332497	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-MW332479	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-MW332478	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-MW332477	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-MW332476	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-MW332475	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-MW332471	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-MW332470	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-MW332469	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-MW332468	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-MW332467	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-MW332465	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-MW332464	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-MW332463	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-MW332462	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-MW332461	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-MW320656	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-MW301594	ncbi_serotype	denv3 # Annotated as denv1 but matches denv3
-MW301593	ncbi_serotype	denv3 # Annotated as denv1 but matches denv3
-MW301592	ncbi_serotype	denv3 # Annotated as denv1 but matches denv3
-MW301591	ncbi_serotype	denv3 # Annotated as denv1 but matches denv3
-MW301590	ncbi_serotype	denv3 # Annotated as denv1 but matches denv3
-MW301589	ncbi_serotype	denv3 # Annotated as denv1 but matches denv3
-MW301588	ncbi_serotype	denv3 # Annotated as denv1 but matches denv3
-MW301587	ncbi_serotype	denv3 # Annotated as denv1 but matches denv3
-MW301586	ncbi_serotype	denv3 # Annotated as denv1 but matches denv3
-MW301585	ncbi_serotype	denv3 # Annotated as denv1 but matches denv3
-MW301584	ncbi_serotype	denv3 # Annotated as denv1 but matches denv3
-MW301583	ncbi_serotype	denv3 # Annotated as denv1 but matches denv3
-MW301582	ncbi_serotype	denv3 # Annotated as denv1 but matches denv3
-MT804426	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-MT804425	ncbi_serotype	denv4 # Annotated as denv1 but matches denv4
-MT804424	ncbi_serotype	denv4 # Annotated as denv1 but matches denv4
-MT804423	ncbi_serotype	denv3 # Annotated as denv1 but matches denv3
-MT804422	ncbi_serotype	denv3 # Annotated as denv1 but matches denv3
-MT804420	ncbi_serotype	denv3 # Annotated as denv1 but matches denv3
-MT804419	ncbi_serotype	denv3 # Annotated as denv1 but matches denv3
-MT804418	ncbi_serotype	denv4 # Annotated as denv1 but matches denv4
-MT804417	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-MT804416	ncbi_serotype	denv4 # Annotated as denv1 but matches denv4
-MT804413	ncbi_serotype	denv3 # Annotated as denv1 but matches denv3
-MT804412	ncbi_serotype	denv3 # Annotated as denv1 but matches denv3
-MT804411	ncbi_serotype	denv4 # Annotated as denv1 but matches denv4
-MT804410	ncbi_serotype	denv4 # Annotated as denv1 but matches denv4
-MT804409	ncbi_serotype	denv4 # Annotated as denv1 but matches denv4
-MT804408	ncbi_serotype	denv4 # Annotated as denv1 but matches denv4
-MT804407	ncbi_serotype	denv4 # Annotated as denv1 but matches denv4
-MT804406	ncbi_serotype	denv4 # Annotated as denv1 but matches denv4
-MB029372	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-M32971	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-M32969	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-M32968	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-M32967	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-M32965	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-M32964	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-M32963	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-M32962	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-M32961	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-M32956	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-M32953	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-M32952	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-M32951	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-M32949	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-M32948	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-M32947	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-M32946	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-M32945	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-M32944	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-M32943	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-M32942	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-M32941	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-M32940	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-M32939	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-M32938	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-M32936	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-M32935	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-M32934	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-M32933	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-M32932	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-LN999961	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-KR029570	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-KR029569	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-KR029568	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-KR029567	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-KR029566	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-KR029565	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-FJ502850	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-AY612201	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
-MT597439	ncbi_serotype	denv4 # Annotated as denv2 but is denv4 based on submitter article https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7952331/ (isolate: 43257)
+JF260983	serotype_genbank	denv2 # denv2/S from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KT026309	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KT445955	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KT445956	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KT445957	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KT445958	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KT445959	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KT445960	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KT445961	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KT445962	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KT445963	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KX059015	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KX059016	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KX059017	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KX059019	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KX059021	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KX059022	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KX059024	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KX059025	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KX059028	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KX059029	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KX059030	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KX059033	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KX059037	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY369949	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY369950	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY369951	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586306	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586307	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586308	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586309	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586310	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586311	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586312	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586313	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586314	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586315	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586316	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586317	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586318	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586319	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586320	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586321	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586322	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586323	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586324	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586325	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586326	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586327	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586328	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586329	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586330	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586331	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586332	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586333	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586334	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586335	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586336	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586337	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586338	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586339	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586340	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586341	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586342	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586343	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586344	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586345	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586346	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586347	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586348	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586349	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586350	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586351	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586352	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586353	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586354	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586355	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586356	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586357	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586358	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586359	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586360	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586361	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586362	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586363	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586364	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586365	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586366	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586367	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586368	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586369	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586370	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586371	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586372	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586373	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586374	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586375	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586376	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586377	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586378	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586379	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586380	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586381	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586382	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586383	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586384	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586385	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586386	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586387	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586388	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586389	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586390	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586391	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586392	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586393	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586394	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586395	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586396	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586397	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586398	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586399	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586400	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586401	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586402	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586403	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586404	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586405	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586406	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586407	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586408	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586409	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586410	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586411	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586412	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586413	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586414	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586415	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586416	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586417	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586418	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586419	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586420	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586421	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586422	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586423	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586424	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586425	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586426	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586427	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586428	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586429	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586430	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586431	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586432	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586433	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586434	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586435	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586436	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586437	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586438	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586439	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586440	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586441	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586442	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586443	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586444	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586445	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586446	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586447	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586448	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586449	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586450	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586451	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586452	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586453	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586454	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586455	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586456	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586457	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586458	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586459	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586460	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586461	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586462	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586463	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586464	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586465	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586466	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586467	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586468	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586469	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586470	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586471	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586472	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586473	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586474	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586475	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586476	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586477	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586478	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586479	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586480	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586481	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586482	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586483	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586484	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586485	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586486	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586487	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586488	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586489	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586490	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586491	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586492	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586493	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586494	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586495	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586496	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586497	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586498	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586499	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586500	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586501	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586502	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586503	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586504	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586505	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586506	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586507	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586508	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586509	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586510	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586511	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586512	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586513	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586514	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586515	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586516	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586517	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586518	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586519	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586520	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586521	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586522	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586523	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586524	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586525	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586526	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586527	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586528	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586529	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586530	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586531	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586532	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586533	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586534	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586535	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586536	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586537	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586538	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586539	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586540	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586541	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586542	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586543	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586544	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586545	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586546	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KY586547	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586548	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586549	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586550	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586551	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586552	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586553	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586554	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586555	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586556	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586557	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586558	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586559	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586560	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586561	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586562	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586563	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586564	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586565	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586566	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586567	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586568	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586569	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586570	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586571	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586572	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586573	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586574	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586575	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586576	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586577	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586578	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586579	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586580	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586581	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586582	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586583	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586584	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586585	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586586	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586587	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586588	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586589	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586590	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586591	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586592	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586593	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586594	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586595	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586596	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586597	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586598	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586599	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586600	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586601	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586602	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586603	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586604	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586605	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586606	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586607	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586608	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586609	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586610	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586611	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586612	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586613	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586614	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586615	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586616	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586617	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586618	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586619	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586620	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586621	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586622	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586623	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586624	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586625	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586626	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586627	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586628	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586629	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586630	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586631	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586632	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586633	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586634	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586635	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586636	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586637	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586638	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586639	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586640	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586641	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586642	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586643	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586644	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586645	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586646	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586647	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586648	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586649	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586650	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586651	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586652	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586653	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586654	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586655	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586656	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586657	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586658	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586659	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586660	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586661	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586662	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586663	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586664	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586665	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586666	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586667	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586668	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586669	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586670	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586671	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586672	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586673	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586674	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586675	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586676	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586677	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586678	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586679	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586680	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586681	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586682	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586683	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586684	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586685	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586686	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586687	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586688	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586689	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586690	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586691	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586692	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586693	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586694	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586695	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586696	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586697	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586698	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586699	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586700	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+KY586701	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586702	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586703	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586704	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586705	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586706	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586707	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586708	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586709	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586710	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586711	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586712	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586713	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586714	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586715	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586716	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586717	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586718	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586719	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586720	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586721	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586722	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586723	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586724	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586725	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586726	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586727	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586728	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586729	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586730	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586731	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586732	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586733	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586734	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586735	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586736	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586737	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586738	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586739	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586740	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586741	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586742	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586743	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586744	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586745	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586746	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586747	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586748	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586749	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586750	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586751	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586752	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586753	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586754	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586755	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586756	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586757	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586758	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586759	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586760	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586761	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586762	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586763	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586764	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586765	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586766	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586767	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586768	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586769	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586770	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586771	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586772	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586773	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586774	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586775	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586776	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586777	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586778	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586779	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586780	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586781	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586782	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586783	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586784	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586785	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586786	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586787	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586788	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586789	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586790	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586791	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586792	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586793	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586794	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586795	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586796	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586797	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586798	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586799	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586800	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586801	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586802	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586803	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586804	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586805	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586806	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586807	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586808	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586809	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586810	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586811	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586812	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586813	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586814	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586815	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586816	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586817	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586818	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586819	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586820	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586821	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586822	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+KY586823	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586824	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586825	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586826	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586840	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586841	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586842	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586843	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586844	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586845	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586846	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586847	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586848	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586849	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586850	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586851	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586852	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586853	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586854	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586855	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586856	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586857	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586858	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586859	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586860	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586861	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586862	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586863	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586864	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586865	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586866	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586867	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586868	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586869	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586870	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586871	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586872	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586873	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586874	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586875	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586876	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586877	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586878	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586879	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586880	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586881	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586882	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586883	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586884	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586885	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586886	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586887	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586888	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586889	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586890	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586891	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586892	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586893	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586894	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586895	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586896	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586897	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586899	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586900	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586901	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586902	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586905	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586906	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586907	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586911	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586913	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586915	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586916	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586920	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586921	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586923	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586924	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586925	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586926	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586927	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586928	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586929	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586930	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586931	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586933	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586934	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586936	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586937	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586941	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586942	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586943	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586944	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586945	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586946	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY977454	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+MG599592	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+MG599593	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+MG599594	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+MG599595	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+MG599596	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+MG599597	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+MG599598	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+MG599599	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+MG599600	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+MG599601	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+MG599602	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+MG599603	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+MG599604	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+MG599605	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+MG599606	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+MG599607	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+MG599608	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+MG599609	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+MG599610	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+MG599611	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+MG599612	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+MG599613	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+MG599614	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+MG599615	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+MG599616	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+MG599617	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+MG599618	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+MG599619	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+MG599620	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+MG599621	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+MG599622	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+MG599623	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+MG599624	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+MG599625	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+MG599626	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+MG599627	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+MG599628	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+MG599629	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+MG599630	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+MG599631	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+MG599632	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+MG599633	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+MG599634	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+MH450295	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+MH450296	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+MH450297	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+MH450298	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+MH450299	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+MH450300	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+MH450301	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+MH450302	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+MH450303	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+MH450304	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+MH450305	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+MH450306	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+MH450307	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+MH450308	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+MH450309	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+MH450310	serotype_genbank	denv2 # denv2 from GenBank record and sequence aligns closest to KM204118 DENV2 WHO reference
+MH450311	serotype_genbank	denv3 # denv3 from GenBank record and sequence aligns closest to KU050695 DENV3 WHO reference
+MN567692	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+MN567693	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+MN567694	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+MN567695	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+MN567696	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+MN567697	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KF907503	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KT026308	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KT026310	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KX059018	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KX059020	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KX059023	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KX059026	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KX059027	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KX059031	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KX059032	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KX059034	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KX059035	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KX059036	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KX812530	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586827	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586828	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586829	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586830	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586831	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586832	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586833	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586834	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586835	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586836	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586837	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586838	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586839	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586898	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586903	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586904	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586908	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586909	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586910	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586912	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586914	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586917	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586918	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586919	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586922	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586932	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586935	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586938	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586939	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KY586940	serotype_genbank	denv4 # denv4 from GenBank record and sequence aligns closest to KR011349 DENV4 WHO reference
+KP772252	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KR052012	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KR071622	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KR919820	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+KR919821	serotype_genbank	denv1 # denv1 from GenBank record and sequence aligns closest to KM204119 DENV1 WHO reference
+ON127553	serotype_genbank	denv3 # Annotated as denv1 but aligns closer to denv3
+ON127551	serotype_genbank	denv3 # Annotated as denv1 but aligns closer to denv3
+ON127538	serotype_genbank	denv3 # Annotated as denv1 but aligns closer to denv3
+ON127534	serotype_genbank	denv3 # Annotated as denv1 but aligns closer to denv3
+ON127419	serotype_genbank	denv3 # Annotated as denv1 but aligns closer to denv3
+ON116130	serotype_genbank	denv3 # Annotated as denv1 but aligns closer to denv3
+ON115819	serotype_genbank	denv3 # Annotated as denv1 but aligns closer to denv3
+ON115817	serotype_genbank	denv3 # Annotated as denv1 but aligns closer to denv3
+ON115815	serotype_genbank	denv3 # Annotated as denv1 but aligns closer to denv3
+ON115812	serotype_genbank	denv3 # Annotated as denv1 but aligns closer to denv3
+ON115183	serotype_genbank	denv3 # Annotated as denv1 but aligns closer to denv3
+ON115030	serotype_genbank	denv3 # Annotated as denv1 but aligns closer to denv3
+ON115026	serotype_genbank	denv3 # Annotated as denv1 but aligns closer to denv3
+ON115024	serotype_genbank	denv3 # Annotated as denv1 but aligns closer to denv3
+ON115022	serotype_genbank	denv3 # Annotated as denv1 but aligns closer to denv3
+ON111446	serotype_genbank	denv3 # Annotated as denv1 but aligns closer to denv3
+ON103391	serotype_genbank	denv3 # Annotated as denv1 but aligns closer to denv3
+ON103303	serotype_genbank	denv3 # Annotated as denv1 but aligns closer to denv3
+OK079104	serotype_genbank	denv3 # Annotated as denv1 but aligns closer to denv3
+ON046278	serotype_genbank	denv2 # Annotated as denv1 but aligns closer to denv2
+ON046277	serotype_genbank	denv2 # Annotated as denv1 but aligns closer to denv2
+ON046276	serotype_genbank	denv2 # Annotated as denv1 but aligns closer to denv2
+ON046275	serotype_genbank	denv2 # Annotated as denv1 but aligns closer to denv2
+ON046274	serotype_genbank	denv2 # Annotated as denv1 but aligns closer to denv2
+ON046273	serotype_genbank	denv2 # Annotated as denv1 but aligns closer to denv2
+ON046272	serotype_genbank	denv2 # Annotated as denv1 but aligns closer to denv2
+ON046271	serotype_genbank	denv2 # Annotated as denv1 but aligns closer to denv2
+ON046270	serotype_genbank	denv2 # Annotated as denv1 but aligns closer to denv2
+ON046269	serotype_genbank	denv2 # Annotated as denv1 but aligns closer to denv2
+ON046268	serotype_genbank	denv2 # Annotated as denv1 but aligns closer to denv2
+ON045733	serotype_genbank	denv4 # Annotated as denv1 but aligns closer to denv4
+S44168	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+OQ520876	serotype_genbank	denv3 # Annotated as denv1 but matches denv3
+OQ520875	serotype_genbank	denv3 # Annotated as denv1 but matches denv3
+OQ520874	serotype_genbank	denv3 # Annotated as denv1 but matches denv3
+OQ520873	serotype_genbank	denv3 # Annotated as denv1 but matches denv3
+OQ520872	serotype_genbank	denv3 # Annotated as denv1 but matches denv3
+OQ519670	serotype_genbank	denv3 # Annotated as denv1 but matches denv3
+OQ519669	serotype_genbank	denv3 # Annotated as denv1 but matches denv3
+OQ519668	serotype_genbank	denv3 # Annotated as denv1 but matches denv3
+OQ519667	serotype_genbank	denv3 # Annotated as denv1 but matches denv3
+OQ519666	serotype_genbank	denv3 # Annotated as denv1 but matches denv3
+OQ519665	serotype_genbank	denv3 # Annotated as denv1 but matches denv3
+OQ519664	serotype_genbank	denv3 # Annotated as denv1 but matches denv3
+OQ519663	serotype_genbank	denv3 # Annotated as denv1 but matches denv3
+OQ519662	serotype_genbank	denv3 # Annotated as denv1 but matches denv3
+OQ519661	serotype_genbank	denv3 # Annotated as denv1 but matches denv3
+OQ519660	serotype_genbank	denv3 # Annotated as denv1 but matches denv3
+OQ519659	serotype_genbank	denv3 # Annotated as denv1 but matches denv3
+OQ519658	serotype_genbank	denv3 # Annotated as denv1 but matches denv3
+OQ519657	serotype_genbank	denv3 # Annotated as denv1 but matches denv3
+OQ519656	serotype_genbank	denv3 # Annotated as denv1 but matches denv3
+OQ519655	serotype_genbank	denv3 # Annotated as denv1 but matches denv3
+OQ519654	serotype_genbank	denv3 # Annotated as denv1 but matches denv3
+OP788175	serotype_genbank	denv4 # Annotated as denv1 but matches denv4
+OP788174	serotype_genbank	denv4 # Annotated as denv1 but matches denv4
+OP788173	serotype_genbank	denv4 # Annotated as denv1 but matches denv4
+OP788172	serotype_genbank	denv4 # Annotated as denv1 but matches denv4
+OP788171	serotype_genbank	denv4 # Annotated as denv1 but matches denv4
+OP788170	serotype_genbank	denv4 # Annotated as denv1 but matches denv4
+OP788169	serotype_genbank	denv4 # Annotated as denv1 but matches denv4
+OP788168	serotype_genbank	denv4 # Annotated as denv1 but matches denv4
+OP788167	serotype_genbank	denv4 # Annotated as denv1 but matches denv4
+OP788166	serotype_genbank	denv4 # Annotated as denv1 but matches denv4
+OP788165	serotype_genbank	denv4 # Annotated as denv1 but matches denv4
+OP788164	serotype_genbank	denv4 # Annotated as denv1 but matches denv4
+OP788163	serotype_genbank	denv4 # Annotated as denv1 but matches denv4
+OP788162	serotype_genbank	denv4 # Annotated as denv1 but matches denv4
+OP788161	serotype_genbank	denv4 # Annotated as denv1 but matches denv4
+OP788160	serotype_genbank	denv4 # Annotated as denv1 but matches denv4
+OP788159	serotype_genbank	denv4 # Annotated as denv1 but matches denv4
+OP788158	serotype_genbank	denv4 # Annotated as denv1 but matches denv4
+OP788157	serotype_genbank	denv4 # Annotated as denv1 but matches denv4
+OP788156	serotype_genbank	denv4 # Annotated as denv1 but matches denv4
+OP788155	serotype_genbank	denv4 # Annotated as denv1 but matches denv4
+OP788154	serotype_genbank	denv4 # Annotated as denv1 but matches denv4
+OP788153	serotype_genbank	denv4 # Annotated as denv1 but matches denv4
+OP788152	serotype_genbank	denv4 # Annotated as denv1 but matches denv4
+OP788151	serotype_genbank	denv4 # Annotated as denv1 but matches denv4
+OP788150	serotype_genbank	denv4 # Annotated as denv1 but matches denv4
+OP788149	serotype_genbank	denv4 # Annotated as denv1 but matches denv4
+OP788148	serotype_genbank	denv4 # Annotated as denv1 but matches denv4
+OP788147	serotype_genbank	denv4 # Annotated as denv1 but matches denv4
+OP788146	serotype_genbank	denv4 # Annotated as denv1 but matches denv4
+OP788145	serotype_genbank	denv4 # Annotated as denv1 but matches denv4
+OP788144	serotype_genbank	denv4 # Annotated as denv1 but matches denv4
+OP788143	serotype_genbank	denv4 # Annotated as denv1 but matches denv4
+OP788142	serotype_genbank	denv4 # Annotated as denv1 but matches denv4
+OP788141	serotype_genbank	denv4 # Annotated as denv1 but matches denv4
+OP788140	serotype_genbank	denv4 # Annotated as denv1 but matches denv4
+OP788139	serotype_genbank	denv4 # Annotated as denv1 but matches denv4
+OP788138	serotype_genbank	denv4 # Annotated as denv1 but matches denv4
+OP788137	serotype_genbank	denv4 # Annotated as denv1 but matches denv4
+OP741244	serotype_genbank	denv3 # Annotated as denv1 but matches denv3
+OP741243	serotype_genbank	denv3 # Annotated as denv1 but matches denv3
+OP740753	serotype_genbank	denv3 # Annotated as denv1 but matches denv3
+OP491597	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+OP491531	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+OP491529	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+OP491465	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+OP435268	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+OP164424	serotype_genbank	denv3 # Annotated as denv1 but matches denv3
+OP164423	serotype_genbank	denv3 # Annotated as denv1 but matches denv3
+OP164422	serotype_genbank	denv3 # Annotated as denv1 but matches denv3
+OP120949	serotype_genbank	denv4 # Annotated as denv1 but matches denv4
+OP120948	serotype_genbank	denv4 # Annotated as denv1 but matches denv4
+OP120947	serotype_genbank	denv4 # Annotated as denv1 but matches denv4
+OP090329	serotype_genbank	denv3 # Annotated as denv1 but matches denv3
+OP090328	serotype_genbank	denv3 # Annotated as denv1 but matches denv3
+OP090327	serotype_genbank	denv3 # Annotated as denv1 but matches denv3
+ON629748	serotype_genbank	denv4 # Annotated as denv1 but matches denv4
+MZ278208	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+MW830396	serotype_genbank	denv4 # Annotated as denv1 but matches denv4
+MW795722	serotype_genbank	denv4 # Annotated as denv1 but matches denv4
+MW795721	serotype_genbank	denv4 # Annotated as denv1 but matches denv4
+MW600550	serotype_genbank	denv4 # Annotated as denv1 but matches denv4
+MW600549	serotype_genbank	denv4 # Annotated as denv1 but matches denv4
+MW600548	serotype_genbank	denv4 # Annotated as denv1 but matches denv4
+MW600547	serotype_genbank	denv4 # Annotated as denv1 but matches denv4
+MW600546	serotype_genbank	denv4 # Annotated as denv1 but matches denv4
+MW600545	serotype_genbank	denv4 # Annotated as denv1 but matches denv4
+MW600544	serotype_genbank	denv4 # Annotated as denv1 but matches denv4
+MW600543	serotype_genbank	denv4 # Annotated as denv1 but matches denv4
+MW600542	serotype_genbank	denv4 # Annotated as denv1 but matches denv4
+MW600541	serotype_genbank	denv4 # Annotated as denv1 but matches denv4
+MW332625	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+MW332624	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+MW332618	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+MW332617	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+MW332592	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+MW332591	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+MW332590	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+MW332589	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+MW332588	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+MW332587	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+MW332586	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+MW332585	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+MW332584	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+MW332583	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+MW332582	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+MW332581	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+MW332580	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+MW332579	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+MW332578	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+MW332577	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+MW332576	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+MW332575	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+MW332509	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+MW332508	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+MW332507	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+MW332506	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+MW332505	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+MW332501	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+MW332500	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+MW332499	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+MW332498	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+MW332497	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+MW332479	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+MW332478	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+MW332477	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+MW332476	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+MW332475	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+MW332471	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+MW332470	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+MW332469	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+MW332468	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+MW332467	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+MW332465	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+MW332464	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+MW332463	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+MW332462	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+MW332461	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+MW320656	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+MW301594	serotype_genbank	denv3 # Annotated as denv1 but matches denv3
+MW301593	serotype_genbank	denv3 # Annotated as denv1 but matches denv3
+MW301592	serotype_genbank	denv3 # Annotated as denv1 but matches denv3
+MW301591	serotype_genbank	denv3 # Annotated as denv1 but matches denv3
+MW301590	serotype_genbank	denv3 # Annotated as denv1 but matches denv3
+MW301589	serotype_genbank	denv3 # Annotated as denv1 but matches denv3
+MW301588	serotype_genbank	denv3 # Annotated as denv1 but matches denv3
+MW301587	serotype_genbank	denv3 # Annotated as denv1 but matches denv3
+MW301586	serotype_genbank	denv3 # Annotated as denv1 but matches denv3
+MW301585	serotype_genbank	denv3 # Annotated as denv1 but matches denv3
+MW301584	serotype_genbank	denv3 # Annotated as denv1 but matches denv3
+MW301583	serotype_genbank	denv3 # Annotated as denv1 but matches denv3
+MW301582	serotype_genbank	denv3 # Annotated as denv1 but matches denv3
+MT804426	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+MT804425	serotype_genbank	denv4 # Annotated as denv1 but matches denv4
+MT804424	serotype_genbank	denv4 # Annotated as denv1 but matches denv4
+MT804423	serotype_genbank	denv3 # Annotated as denv1 but matches denv3
+MT804422	serotype_genbank	denv3 # Annotated as denv1 but matches denv3
+MT804420	serotype_genbank	denv3 # Annotated as denv1 but matches denv3
+MT804419	serotype_genbank	denv3 # Annotated as denv1 but matches denv3
+MT804418	serotype_genbank	denv4 # Annotated as denv1 but matches denv4
+MT804417	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+MT804416	serotype_genbank	denv4 # Annotated as denv1 but matches denv4
+MT804413	serotype_genbank	denv3 # Annotated as denv1 but matches denv3
+MT804412	serotype_genbank	denv3 # Annotated as denv1 but matches denv3
+MT804411	serotype_genbank	denv4 # Annotated as denv1 but matches denv4
+MT804410	serotype_genbank	denv4 # Annotated as denv1 but matches denv4
+MT804409	serotype_genbank	denv4 # Annotated as denv1 but matches denv4
+MT804408	serotype_genbank	denv4 # Annotated as denv1 but matches denv4
+MT804407	serotype_genbank	denv4 # Annotated as denv1 but matches denv4
+MT804406	serotype_genbank	denv4 # Annotated as denv1 but matches denv4
+MB029372	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+M32971	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+M32969	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+M32968	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+M32967	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+M32965	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+M32964	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+M32963	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+M32962	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+M32961	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+M32956	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+M32953	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+M32952	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+M32951	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+M32949	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+M32948	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+M32947	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+M32946	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+M32945	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+M32944	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+M32943	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+M32942	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+M32941	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+M32940	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+M32939	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+M32938	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+M32936	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+M32935	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+M32934	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+M32933	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+M32932	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+LN999961	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+KR029570	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+KR029569	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+KR029568	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+KR029567	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+KR029566	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+KR029565	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+FJ502850	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+AY612201	serotype_genbank	denv2 # Annotated as denv1 but matches denv2
+MT597439	serotype_genbank	denv4 # Annotated as denv2 but is denv4 based on submitter article https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7952331/ (isolate: 43257)

--- a/ingest/defaults/config.yaml
+++ b/ingest/defaults/config.yaml
@@ -115,7 +115,7 @@ nextclade:
   # Nextclade Fields to rename to metadata field names.
   field_map:
     seqName: genbank_accession # ID field used to merge annotations
-    clade: nextclade_subtype
+    clade: genotype_nextclade
     alignmentStart: alignmentStart
     alignmentEnd: alignmentEnd
     coverage: genome_coverage

--- a/ingest/defaults/config.yaml
+++ b/ingest/defaults/config.yaml
@@ -101,11 +101,11 @@ curate:
     'host',
     'release_date',
     'update_date',
-    'serotype_genbank', # inferred from virus_tax_id
     'sra_accessions',
     'abbr_authors',
     'authors',
-    'institution'
+    'institution',
+    'serotype_genbank', # inferred from virus_tax_id
   ]
 
 nextclade:

--- a/ingest/defaults/config.yaml
+++ b/ingest/defaults/config.yaml
@@ -79,6 +79,8 @@ curate:
   local_geolocation_rules: 'defaults/geolocation-rules.tsv'
   # User annotations file
   annotations: 'defaults/annotations.tsv'
+  # Serotype field name inferred from NCBI Genbank annotation
+  serotype_field: 'serotype_genbank'
   # ID field used to merge annotations
   annotations_id: 'genbank_accession'
   # Field to use as the sequence ID in the FASTA file
@@ -99,7 +101,7 @@ curate:
     'host',
     'release_date',
     'update_date',
-    'ncbi_serotype', # inferred from virus_tax_id
+    'serotype_genbank', # inferred from virus_tax_id
     'sra_accessions',
     'abbr_authors',
     'authors',

--- a/ingest/rules/curate.smk
+++ b/ingest/rules/curate.smk
@@ -66,6 +66,7 @@ rule curate:
         authors_default_value=config["curate"]["authors_default_value"],
         abbr_authors_field=config["curate"]["abbr_authors_field"],
         annotations_id=config["curate"]["annotations_id"],
+        serotype_field=config["curate"]["serotype_field"],
         metadata_columns=config["curate"]["metadata_columns"],
         id_field=config["curate"]["id_field"],
         sequence_field=config["curate"]["sequence_field"],
@@ -93,6 +94,7 @@ rule curate:
             | ./vendored/apply-geolocation-rules \
                 --geolocation-rules {input.all_geolocation_rules} \
             | ./bin/infer-dengue-serotype.py \
+                --out-col {params.serotype_field} \
             | ./vendored/merge-user-metadata \
                 --annotations {input.annotations} \
                 --id-field {params.annotations_id} \

--- a/ingest/rules/nextclade.smk
+++ b/ingest/rules/nextclade.smk
@@ -7,7 +7,7 @@ REQUIRED INPUTS:
     nextclade_datasets = ../nextclade_data/{serotype}
 OUTPUTS:
     metadata        = results/metadata_{serotype}.tsv
-    nextclade       = results/nextclade_subtypes.tsv
+    nextclade       = results/nextclade_genotypes.tsv
 See Nextclade docs for more details on usage, inputs, and outputs if you would
 like to customize the rules:
 https://docs.nextstrain.org/projects/nextclade/page/user/nextclade-cli.html
@@ -18,7 +18,7 @@ SEROTYPE_CONSTRAINTS = '|'.join(SUPPORTED_NEXTCLADE_SEROTYPES)
 
 rule nextclade_denvX:
     """
-    For each type, classify into the appropriate subtype
+    For each type, classify into the appropriate Dengue genotype
     1. Capture the alignment
     2. Capture the translations of gene(s) of interest
 
@@ -52,14 +52,14 @@ rule nextclade_denvX:
           {input.sequences}
         """
 
-rule concat_nextclade_subtype_results:
+rule concat_genotype_nextclade_results:
     """
-    Concatenate all the nextclade results for dengue subtype classification
+    Concatenate all the nextclade results for dengue genotype classification
     """
     input:
         nextclade_results_files = expand("data/nextclade_results/nextclade_{serotype}.tsv", serotype=SUPPORTED_NEXTCLADE_SEROTYPES),
     output:
-        nextclade_subtypes="results/nextclade_subtypes.tsv",
+        genotype_nextclade="results/nextclade_genotypes.tsv",
     params:
         input_nextclade_fields=",".join([f'{key}' for key, value in config["nextclade"]["field_map"].items()]),
         output_nextclade_fields=",".join([f'{value}' for key, value in config["nextclade"]["field_map"].items()]),
@@ -67,11 +67,11 @@ rule concat_nextclade_subtype_results:
         """
         echo "{params.output_nextclade_fields}" \
         | tr ',' '\t' \
-        > {output.nextclade_subtypes}
+        > {output.genotype_nextclade}
 
         tsv-select -H -f "{params.input_nextclade_fields}" {input.nextclade_results_files} \
         | awk 'NR>1 {{print}}' \
-        >> {output.nextclade_subtypes}
+        >> {output.genotype_nextclade}
         """
 
 rule append_nextclade_columns:
@@ -80,7 +80,7 @@ rule append_nextclade_columns:
     """
     input:
         metadata="data/metadata_all.tsv",
-        nextclade_subtypes="results/nextclade_subtypes.tsv",
+        genotype_nextclade="results/nextclade_genotypes.tsv",
     output:
         metadata_all="data/metadata_nextclade.tsv",
     params:
@@ -89,7 +89,7 @@ rule append_nextclade_columns:
     shell:
         """
         tsv-join -H \
-            --filter-file {input.nextclade_subtypes} \
+            --filter-file {input.genotype_nextclade} \
             --key-fields {params.id_field} \
             --append-fields {params.output_nextclade_fields} \
             --write-all ? \

--- a/ingest/rules/nextclade.smk
+++ b/ingest/rules/nextclade.smk
@@ -164,7 +164,9 @@ rule split_metadata_by_serotype:
         serotype_metadata="results/metadata_{serotype}.tsv"
     wildcard_constraints:
         serotype=SEROTYPE_CONSTRAINTS
+    params:
+        serotype_field=config["curate"]["serotype_field"],
     shell:
         """
-        tsv-filter -H --str-eq ncbi_serotype:{wildcards.serotype} {input.metadata} > {output.serotype_metadata}
+        tsv-filter -H --str-eq {params.serotype_field}:{wildcards.serotype} {input.metadata} > {output.serotype_metadata}
         """

--- a/ingest/rules/split_serotypes.smk
+++ b/ingest/rules/split_serotypes.smk
@@ -12,9 +12,9 @@ This will produce output files as
 Parameters are expected to be defined in `config.curate`.
 """
 
-rule split_by_ncbi_serotype:
+rule split_by_serotype_genbank:
     """
-    Split the data by serotype based on the NCBI metadata.
+    Split the data by serotype based on the NCBI Genbank metadata.
     """
     input:
         metadata = "data/metadata_all.tsv",
@@ -22,13 +22,14 @@ rule split_by_ncbi_serotype:
     output:
         sequences = "results/sequences_{serotype}.fasta"
     params:
-        id_field = config["curate"]["id_field"]
+        id_field = config["curate"]["id_field"],
+        serotype_field = config["curate"]["serotype_field"]
     shell:
         """
         augur filter \
           --sequences {input.sequences} \
           --metadata {input.metadata} \
           --metadata-id-columns {params.id_field} \
-          --query "ncbi_serotype=='{wildcards.serotype}'" \
+          --query "{params.serotype_field}=='{wildcards.serotype}'" \
           --output-sequences {output.sequences}
         """

--- a/phylogenetic/config/color_orderings.tsv
+++ b/phylogenetic/config/color_orderings.tsv
@@ -235,10 +235,10 @@ recency	New
 
 ################
 
-ncbi_serotype	denv1
-ncbi_serotype	denv2
-ncbi_serotype	denv3
-ncbi_serotype	denv4
+serotype_genbank	denv1
+serotype_genbank	denv2
+serotype_genbank	denv3
+serotype_genbank	denv4
 
 nextclade_subtype	DENV1/I
 nextclade_subtype	DENV1/II

--- a/phylogenetic/config/color_orderings.tsv
+++ b/phylogenetic/config/color_orderings.tsv
@@ -240,23 +240,23 @@ serotype_genbank	denv2
 serotype_genbank	denv3
 serotype_genbank	denv4
 
-nextclade_subtype	DENV1/I
-nextclade_subtype	DENV1/II
-nextclade_subtype	DENV1/III
-nextclade_subtype	DENV1/IV
-nextclade_subtype	DENV1/V
-nextclade_subtype	DENV2/AA
-nextclade_subtype	DENV2/AI
-nextclade_subtype	DENV2/AII
-nextclade_subtype	DENV2/AM
-nextclade_subtype	DENV2/C
-nextclade_subtype	DENV2/S
-nextclade_subtype	DENV3/I
-nextclade_subtype	DENV3/II
-nextclade_subtype	DENV3/III
-nextclade_subtype	DENV3/IV
-nextclade_subtype	DENV4/I
-nextclade_subtype	DENV4/II
-nextclade_subtype	DENV4/S
+genotype_nextclade	DENV1/I
+genotype_nextclade	DENV1/II
+genotype_nextclade	DENV1/III
+genotype_nextclade	DENV1/IV
+genotype_nextclade	DENV1/V
+genotype_nextclade	DENV2/AA
+genotype_nextclade	DENV2/AI
+genotype_nextclade	DENV2/AII
+genotype_nextclade	DENV2/AM
+genotype_nextclade	DENV2/C
+genotype_nextclade	DENV2/S
+genotype_nextclade	DENV3/I
+genotype_nextclade	DENV3/II
+genotype_nextclade	DENV3/III
+genotype_nextclade	DENV3/IV
+genotype_nextclade	DENV4/I
+genotype_nextclade	DENV4/II
+genotype_nextclade	DENV4/S
 
 ################

--- a/phylogenetic/config/config_dengue.yaml
+++ b/phylogenetic/config/config_dengue.yaml
@@ -23,11 +23,11 @@ filter:
 traits:
   sampling_bias_correction: '3'
   traits_columns:
-    all: 'region serotype_genbank nextclade_subtype'
-    denv1: 'country region serotype_genbank nextclade_subtype'
-    denv2: 'country region serotype_genbank nextclade_subtype'
-    denv3: 'country region serotype_genbank nextclade_subtype'
-    denv4: 'country region serotype_genbank nextclade_subtype'
+    all: 'region serotype_genbank genotype_nextclade'
+    denv1: 'country region serotype_genbank genotype_nextclade'
+    denv2: 'country region serotype_genbank genotype_nextclade'
+    denv3: 'country region serotype_genbank genotype_nextclade'
+    denv4: 'country region serotype_genbank genotype_nextclade'
 
 clades:
   clade_definitions:

--- a/phylogenetic/config/config_dengue.yaml
+++ b/phylogenetic/config/config_dengue.yaml
@@ -23,11 +23,11 @@ filter:
 traits:
   sampling_bias_correction: '3'
   traits_columns:
-    all: 'region ncbi_serotype nextclade_subtype'
-    denv1: 'country region ncbi_serotype nextclade_subtype'
-    denv2: 'country region ncbi_serotype nextclade_subtype'
-    denv3: 'country region ncbi_serotype nextclade_subtype'
-    denv4: 'country region ncbi_serotype nextclade_subtype'
+    all: 'region serotype_genbank nextclade_subtype'
+    denv1: 'country region serotype_genbank nextclade_subtype'
+    denv2: 'country region serotype_genbank nextclade_subtype'
+    denv3: 'country region serotype_genbank nextclade_subtype'
+    denv4: 'country region serotype_genbank nextclade_subtype'
 
 clades:
   clade_definitions:

--- a/phylogenetic/rules/export.smk
+++ b/phylogenetic/rules/export.smk
@@ -73,11 +73,6 @@ rule prepare_auspice_config:
                 "type": "categorical"
               },
               {
-                "key": params.replace_clade_key,
-                "title": params.replace_clade_title,
-                "type": "categorical"
-              },
-              {
                 "key": "genotype_nextclade",
                 "title": "Dengue Genotype (Nextclade)",
                 "type": "categorical"
@@ -105,6 +100,20 @@ rule prepare_auspice_config:
               "genbank_accession"
             ]
           }
+
+        # During genome/dengue_all workflows, clade membership represents Serotype
+        # While genome/dengue_denvX workflows, clade_membership represents the more detailed Genotype
+        if params.replace_clade_key == 'clade_membership':
+            if wildcards.gene in ['genome'] and wildcards.serotype in ['all']:
+                clade_membership_title="Serotype (Nextstrain)"
+            else:
+                clade_membership_title="Dengue Genotype (Nextstrain)"
+
+            data["colorings"].append({
+                "key": "clade_membership",
+                "title": clade_membership_title,
+                "type": "categorical"
+            })
 
         with open(output.auspice_config, 'w') as fh:
             json.dump(data, fh, indent=2)

--- a/phylogenetic/rules/export.smk
+++ b/phylogenetic/rules/export.smk
@@ -114,6 +114,10 @@ rule prepare_auspice_config:
                 "title": clade_membership_title,
                 "type": "categorical"
             })
+        else:
+            # During E/dengue_all workflows, default color by Serotype
+            if wildcards.serotype in ['all']:
+                data["display_defaults"]["color_by"]="serotype_genbank"
 
         with open(output.auspice_config, 'w') as fh:
             json.dump(data, fh, indent=2)

--- a/phylogenetic/rules/export.smk
+++ b/phylogenetic/rules/export.smk
@@ -42,8 +42,8 @@ rule prepare_auspice_config:
     output:
         auspice_config="results/config/{gene}/auspice_config_{serotype}.json",
     params:
-        replace_clade_key=lambda wildcard: r"clade_membership" if wildcard.gene in ['genome'] else r"nextclade_subtype",
-        replace_clade_title=lambda wildcard: r"Serotype" if wildcard.serotype in ['all'] else r"DENV genotype",
+        replace_clade_key=lambda wildcard: r"clade_membership" if wildcard.gene in ['genome'] else r"genotype_nextclade",
+        replace_clade_title=lambda wildcard: r"Serotype" if wildcard.serotype in ['all'] else r"Dengue Genotype (Nextclade)",
     run:
         data = {
             "title": "Real-time tracking of dengue virus evolution",
@@ -78,8 +78,8 @@ rule prepare_auspice_config:
                 "type": "categorical"
               },
               {
-                "key": "nextclade_subtype",
-                "title": "Nextclade genotype",
+                "key": "genotype_nextclade",
+                "title": "Dengue Genotype (Nextclade)",
                 "type": "categorical"
               },
               {

--- a/phylogenetic/rules/export.smk
+++ b/phylogenetic/rules/export.smk
@@ -83,8 +83,8 @@ rule prepare_auspice_config:
                 "type": "categorical"
               },
               {
-                "key": "ncbi_serotype",
-                "title": "NCBI serotype",
+                "key": "serotype_genbank",
+                "title": "Serotype (Genbank metadata)",
                 "type": "categorical"
               }
             ],


### PR DESCRIPTION
## Description of proposed changes

For Dengue serotype, genotype, and the various methods we employ to derive them for a specific strain (NCBI, Nextclade, augur clades (Nextstrain)), this PR is an implementation of consistent metadata column names and auspice color titles following the plan in https://github.com/nextstrain/dengue/issues/41#issuecomment-2113248913

## Related issue(s)

* https://github.com/nextstrain/dengue/issues/41

## Checklist

- [x] Checks pass
- [x] Test builds
	- [x] Ingest (see [run here](https://github.com/nextstrain/dengue/actions/runs/9165263517))
	- [x] Phylogenetic (see [run here](https://github.com/nextstrain/dengue/actions/runs/9176620823))

Link to test builds from this branch: 

| | genome | E gene |
| :--| :-- | :--|
| all   | [all/genome](https://next.nextstrain.org/staging/dengue/trials/serogeno20240518/dengue/all/genome)     | [all/E](https://next.nextstrain.org/staging/dengue/trials/serogeno20240518/dengue/all/E)     |
| denv1 | [denv1/genome](https://next.nextstrain.org/staging/dengue/trials/serogeno20240518/dengue/denv1/genome) | [denv1/E](https://next.nextstrain.org/staging/dengue/trials/serogeno20240518/dengue/denv1/E) |
| denv2 | [denv2/genome](https://next.nextstrain.org/staging/dengue/trials/serogeno20240518/dengue/denv2/genome) | [denv2/E](https://next.nextstrain.org/staging/dengue/trials/serogeno20240518/dengue/denv2/E) |
| denv3 | [denv3/genome](https://next.nextstrain.org/staging/dengue/trials/serogeno20240518/dengue/denv3/genome) | [denv3/E](https://next.nextstrain.org/staging/dengue/trials/serogeno20240518/dengue/denv3/E) |
| denv4 | [denv4/genome](https://next.nextstrain.org/staging/dengue/trials/serogeno20240518/dengue/denv4/genome) | [denv4/E](https://next.nextstrain.org/staging/dengue/trials/serogeno20240518/dengue/denv4/E) |

or for a visual summary of the default color titles for the different trees:

<img src="https://github.com/nextstrain/dengue/assets/1077254/d42e8a02-5a2d-42cc-9c5d-eb2bea24613a"  width="400"/>

