### PR TITLE
Fix serotype annotation for MT597439

### DIFF
--- a/ingest/defaults/annotations.tsv
+++ b/ingest/defaults/annotations.tsv
@@ -1000,3 +1000,4 @@ KR029566	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
 KR029565	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
 FJ502850	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
 AY612201	ncbi_serotype	denv2 # Annotated as denv1 but matches denv2
+MT597439	ncbi_serotype	denv4 # Annotated as denv2 but is denv4 based on submitter article https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7952331/ (isolate: 43257)

--- a/phylogenetic/config/exclude.txt
+++ b/phylogenetic/config/exclude.txt
@@ -32,7 +32,6 @@ EF051521 # ZS01/01 # metadata issue
 MT929160 # Vero # cell line
 MH048676 # MS13002673 # too divergent
 MH048674 # MS11011405 # too divergent
-MT597439 # V43257 # too divergent
 MN448607 # KDC0574A2_06/02/2011 # too divergent
 ON046268 # 00178/03 # too divergent
 ON046278 # 00759/12 # too divergent


### PR DESCRIPTION
## Description of proposed changes

Fixes: https://github.com/nextstrain/dengue/issues/54

[MT597439](https://www.ncbi.nlm.nih.gov/nuccore/MT597439) is incorrectly annotated as `/organism="dengue virus type 2"` in NCBI but should be ``/organism="dengue virus type 4"`` based on the [submitter's publication](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7952331/) where they correctly assign it as DENV4/II (See Fig 1b, sample 43257 highlighted in yellow).

Separately, someone will be requesting that NCBI to correct this entry. But this commit manually corrects the serotype annotation in the annotations.tsv file in the meanwhile.

## Related issue(s)

* https://github.com/nextstrain/dengue/issues/54

## Checklist

- [x] Checks pass
