### PR TITLE
Hotfix: Infer ancestral root in the phylogenetic workflow

### DIFF
--- a/phylogenetic/rules/annotate_phylogeny.smk
+++ b/phylogenetic/rules/annotate_phylogeny.smk
@@ -26,7 +26,6 @@ rule ancestral:
     input:
         tree = "results/{gene}/tree_{serotype}.nwk",
         alignment = "results/{gene}/aligned_{serotype}.fasta",
-        root_sequence = lambda wildcard: "config/reference_{serotype}_genome.gb" if wildcard.gene in ['genome'] else "results/config/reference_{serotype}_{gene}.gb",
     output:
         node_data = "results/{gene}/nt-muts_{serotype}.json"
     params:
@@ -37,7 +36,6 @@ rule ancestral:
             --tree {input.tree} \
             --alignment {input.alignment} \
             --output-node-data {output.node_data} \
-            --root-sequence {input.root_sequence} \
             --inference {params.inference}
         """
 


### PR DESCRIPTION
## Description of proposed changes

This commit reverts the change introduced in https://github.com/nextstrain/dengue/pull/57/commits/94316551c8af6270134411305098a0694eb17811 which set the REFSEQ references as the roots in the auspice trees. Turns out this is not the desired behavior for the dengue phylogenetic trees.

Instead, we want to use the sequences and metadata to infer the ancestral root of each tree. These inferred-ancestral roots can then be used in building the nextclade datasets as hard-coded reference and root of the scaffold trees.

## Related issue(s)

* https://github.com/nextstrain/dengue/pull/58

## Checklist

- [x] Checks pass
- [x] Phylogenetic tree looks reasonable (see [github action run here](https://github.com/nextstrain/dengue/actions/runs/9358609778))


|  | genome |
| :-- | :-- |
| all   | [all/genome](https://next.nextstrain.org/staging/dengue/trials/inferroot20240603/dengue/all/genome)     | 
| denv1 | [denv1/genome](https://next.nextstrain.org/staging/dengue/trials/inferroot20240603/dengue/denv1/genome) |
| denv2 | [denv2/genome](https://next.nextstrain.org/staging/dengue/trials/inferroot20240603/dengue/denv2/genome) |
| denv3 | [denv3/genome](https://next.nextstrain.org/staging/dengue/trials/inferroot20240603/dengue/denv3/genome) |
| denv4 | [denv4/genome](https://next.nextstrain.org/staging/dengue/trials/inferroot20240603/dengue/denv4/genome) |
