### PR TITLE
Adds rest of the genes for gene coverage columns

### DIFF
--- a/ingest/defaults/config.yaml
+++ b/ingest/defaults/config.yaml
@@ -111,7 +111,7 @@ curate:
 nextclade:
   min_length: 1000 # E gene length is approximately 1400nt
   min_seed_cover: 0.1
-  gene: ['E','NS1']
+  gene: ['E','C','M','pr','NS1','NS2A','NS2B','NS3','NS4A','2K','NS4B','NS5']
   # Nextclade Fields to rename to metadata field names.
   field_map:
     seqName: genbank_accession # ID field used to merge annotations


### PR DESCRIPTION
## Description of proposed changes

This PR enhances the gene coverage calculation by incorporating the remaining genes. This addition provides a more comprehensive view of sequencing practices, allowing us to evaluate if data providers tend to sequence specific genes-of-interest or the whole genome.

## Related issue(s)

* Somewhat related to https://github.com/nextstrain/pathogen-repo-guide/issues/50

## Checklist

- [x] Checks pass
