### PR TITLE
Phylogenetic: Increase sampling in the `all` tree to nearly 4K tips

### DIFF
--- a/phylogenetic/defaults/config_dengue.yaml
+++ b/phylogenetic/defaults/config_dengue.yaml
@@ -15,7 +15,7 @@ filter:
     genome: 5000
     E: 1000
   sequences_per_group:
-    all: '10'
+    all: '36'
     denv1: '36'
     denv2: '36'
     denv3: '36'

--- a/phylogenetic/defaults/config_dengue.yaml
+++ b/phylogenetic/defaults/config_dengue.yaml
@@ -14,12 +14,7 @@ filter:
   min_length:
     genome: 5000
     E: 1000
-  sequences_per_group:
-    all: '36'
-    denv1: '36'
-    denv2: '36'
-    denv3: '36'
-    denv4: '36'
+  subsample_max_sequences: '4000'
 
 traits:
   sampling_bias_correction: '3'

--- a/phylogenetic/rules/prepare_sequences.smk
+++ b/phylogenetic/rules/prepare_sequences.smk
@@ -60,7 +60,7 @@ rule filter:
         sequences = "results/{gene}/filtered_{serotype}.fasta"
     params:
         group_by = config['filter']['group_by'],
-        sequences_per_group = lambda wildcards: config['filter']['sequences_per_group'][wildcards.serotype],
+        subsample_max_sequences = config['filter']['subsample_max_sequences'],
         min_length = lambda wildcard: config['filter']['min_length'][wildcard.gene],
         strain_id = config.get("strain_id_field", "strain"),
     shell:
@@ -73,7 +73,7 @@ rule filter:
             --include {input.include} \
             --output {output.sequences} \
             --group-by {params.group_by} \
-            --sequences-per-group {params.sequences_per_group} \
+            --subsample-max-sequences {params.subsample_max_sequences} \
             --min-length {params.min_length} \
             --exclude-where country=? region=? date=? is_lab_host='true' \
             --query-columns is_lab_host:str


### PR DESCRIPTION
## Description of proposed changes

Increased the subsampling of the `all` trees to align more closely with the number of tips in the serotype-specific trees (approximately 4K tips). After exploring a few implementation approaches, this method was selected as the most straightforward and effective for now.

Local tests show the following subsampling results:

* genome: 3869 strains passed all filters
* E: 3931 strains passed all filters


## A few implementation approaches attempted: 
[Edit: Added later, sorry I should have written more detail. Questions or suggestions are still welcome]

1. **sequences_per_group**: Increase the `all` `sequences_per_group` parameter to get approximately 4k samples.
	1. ~~This approach is implemented in this PR.~~ --> Switched to approach 2
2. **subsample_max_sequences**: Simplify the subsampling logic by setting subsampling to `subsample_max_sequences` to ~4k samples for `all` and `serotype` subsampling.
	1. ~~This approach resulted in a loss of temporal signal, making it difficult to infer a reasonable molecular clock rate.~~
	2. ~~[See the x-axis for the tangletree on the left as compared to the original on the right](https://next.nextstrain.org/staging/dengue/trials/maxsequences/dengue/all/genome:dengue/all/genome).~~
	3. [Edit: Using both `--subsample-max-sequences` and `-group-by` fixed the problem]
3. **subsampling_configurable logic**: Swap to the [subsampling_configurable logic](https://github.com/nextstrain/WNV/blob/9c7ddac3baf76157412d58c7c76a0cf4a347cb77/phylogenetic/defaults/config.yaml#L67-L69) we currently have in WNV pipelines.
	1. This approach is more complex for layered subsampling and may require further team discussions, as there are [varying subsampling implementations noted here](https://github.com/nextstrain/dengue/issues/90#issuecomment-2579195737).

## Related issue(s)

* https://github.com/nextstrain/dengue/issues/90

## Checklist

- [x] Checks pass
- [x] Ran the phylogenetic workflow, confirming that the `all` tree contains nearly 4k tips: 
    - https://next.nextstrain.org/staging/dengue/trials/subsampling/dengue/all/genome
    - https://next.nextstrain.org/staging/dengue/trials/subsampling/dengue/all/E



