### PR TITLE
Enhancement: Annotate host on the phylogenetic trees

### DIFF
--- a/ingest/defaults/config.yaml
+++ b/ingest/defaults/config.yaml
@@ -109,6 +109,8 @@ curate:
     "location",
     "length",
     "host",
+    "host_genus",
+    "host_type",
     "is_lab_host",
     "date_released",
     "date_updated",

--- a/ingest/defaults/host_hostgenus_hosttype_map.tsv
+++ b/ingest/defaults/host_hostgenus_hosttype_map.tsv
@@ -1,0 +1,290 @@
+host	host_genus	host_type
+Homo sapiens	Homo	Human
+Aedeomyia madagascarica	Aedeomyia	Mosquito
+Aedes albopictus	Aedes	Mosquito
+Aedes cinereus	Aedes	Mosquito
+Aedes dalzieli	Aedes	Mosquito
+Aedes japonicus	Aedes	Mosquito
+Aedes rossicus	Aedes	Mosquito
+Aedes sp.	Aedes	Mosquito
+Aedes vexans	Aedes	Mosquito
+Anopheles atroparvus	Anopheles	Mosquito
+Anopheles bancroftii	Anopheles	Mosquito
+Anopheles coustani	Anopheles	Mosquito
+Anopheles farauti	Anopheles	Mosquito
+Anopheles hyrcanus	Anopheles	Mosquito
+Anopheles maculipennis	Anopheles	Mosquito
+Anopheles messeae	Anopheles	Mosquito
+Anopheles pauliani	Anopheles	Mosquito
+Anopheles plumbeus	Anopheles	Mosquito
+Anopheles sp.	Anopheles	Mosquito
+Anopheles stephensi	Anopheles	Mosquito
+Coquillettidia	Coquillettidia	Mosquito
+Coquillettidia perturbans	Coquillettidia	Mosquito
+Coquillettidia richiardii	Coquillettidia	Mosquito
+Culex	Culex	Mosquito
+Culex annulirostris	Culex	Mosquito
+Culex antennatus	Culex	Mosquito
+Culex bitaeniorhynchus	Culex	Mosquito
+Culex erraticus	Culex	Mosquito
+Culex erythrothorax	Culex	Mosquito
+Culex gelidus	Culex	Mosquito
+Culex interrogator	Culex	Mosquito
+Culex modestus	Culex	Mosquito
+Culex neavei	Culex	Mosquito
+Culex nigripalpus	Culex	Mosquito
+Culex perexiguus	Culex	Mosquito
+Culex perfuscus	Culex	Mosquito
+Culex pipiens	Culex	Mosquito
+Culex pipiens complex	Culex	Mosquito
+Culex pipiens pipiens	Culex	Mosquito
+Culex pipiens sensu lato	Culex	Mosquito
+Culex poicilipes	Culex	Mosquito
+Culex pseudovishnui	Culex	Mosquito
+Culex pullus	Culex	Mosquito
+Culex quinquefasciatus	Culex	Mosquito
+Culex restuans	Culex	Mosquito
+Culex salinarius	Culex	Mosquito
+Culex sitiens	Culex	Mosquito
+Culex squamosus	Culex	Mosquito
+Culex stigmatosoma	Culex	Mosquito
+Culex tarsalis	Culex	Mosquito
+Culex theileri	Culex	Mosquito
+Culex tritaeniorhynchus	Culex	Mosquito
+Culex univittatus	Culex	Mosquito
+Culex vishnui	Culex	Mosquito
+Culex whitmorei	Culex	Mosquito
+Culicidae	Culicidae	Mosquito
+Culiseta	Culiseta	Mosquito
+Culiseta inornata	Culiseta	Mosquito
+Culiseta longiareolata	Culiseta	Mosquito
+Culiseta melanura	Culiseta	Mosquito
+Culiseta morsitans	Culiseta	Mosquito
+Mansonia uniformis	Mansonia	Mosquito
+Ochlerotatus canadensis	Ochlerotatus	Mosquito
+Ochlerotatus cantator	Ochlerotatus	Mosquito
+Ochlerotatus caspius	Ochlerotatus	Mosquito
+Ochlerotatus communis	Ochlerotatus	Mosquito
+Ochlerotatus dorsalis	Ochlerotatus	Mosquito
+Ochlerotatus flavescens	Ochlerotatus	Mosquito
+Ochlerotatus sollicitans	Ochlerotatus	Mosquito
+Ochlerotatus spencerii	Ochlerotatus	Mosquito
+Ochlerotatus sticticus	Ochlerotatus	Mosquito
+Ochlerotatus taeniorhynchus	Ochlerotatus	Mosquito
+Ochlerotatus triseriatus	Ochlerotatus	Mosquito
+Ochlerotatus trivittatus	Ochlerotatus	Mosquito
+Psorophora	Psorophora	Mosquito
+Psorophora ferox	Psorophora	Mosquito
+Uranotaenia	Uranotaenia	Mosquito
+Uranotaenia unguiculata	Uranotaenia	Mosquito
+Accipiter	Accipiter	Bird
+Accipiter cooperii	Accipiter	Bird
+Accipiter gentilis	Accipiter	Bird
+Accipiter nisus	Accipiter	Bird
+Accipiter striatus	Accipiter	Bird
+Accipitridae	Accipitridae	Bird
+Acrocephalus dumetorum	Acrocephalus	Bird
+Actitis macularius	Actitis	Bird
+Aegithalos caudatus	Aegithalos	Bird
+Aegypius monachus	Aegypius	Bird
+Agelaius phoeniceus	Agelaius	Bird
+Alopochen aegyptiaca	Alopochen	Bird
+Anas platyrhynchos	Anas	Bird
+Anatidae	Anatidae	Bird
+Anser	Anser	Bird
+Aphelocoma	Aphelocoma	Bird
+Aphelocoma californica	Aphelocoma	Bird
+Apus apus	Apus	Bird
+Aquila adalberti	Aquila	Bird
+Aquila chrysaetos	Aquila	Bird
+Aquila fasciata	Aquila	Bird
+Ardeidae	Ardeidae	Bird
+Asio flammeus	Asio	Bird
+Asio otus	Asio	Bird
+Athene noctua	Athene	Bird
+Aves	Aves	Bird
+Baeolophus bicolor	Baeolophus	Bird
+Baeolophus inornatus	Baeolophus	Bird
+Bombycilla garrulus	Bombycilla	Bird
+Bonasa umbellus	Bonasa	Bird
+Branta canadensis	Branta	Bird
+Bubo scandiacus	Bubo	Bird
+Bubo virginianus	Bubo	Bird
+Bubulcus ibis	Bubulcus	Bird
+Buteo	Buteo	Bird
+Buteo buteo	Buteo	Bird
+Buteo jamaicensis	Buteo	Bird
+Buteo lineatus	Buteo	Bird
+Buteo regalis	Buteo	Bird
+Buteo swainsoni	Buteo	Bird
+Butorides virescens	Butorides	Bird
+Calidris alba	Calidris	Bird
+Calypte costae	Calypte	Bird
+Cardinalis	Cardinalis	Bird
+Cardinalis cardinalis	Cardinalis	Bird
+Charadrius melodus	Charadrius	Bird
+Chroicocephalus ridibundus	Chroicocephalus	Bird
+Ciconiidae	Ciconiidae	Bird
+Clanga pomarina	Clanga	Bird
+Colaptes auratus	Colaptes	Bird
+Coloeus monedula	Coloeus	Bird
+Columba livia	Columba	Bird
+Columba palumbus	Columba	Bird
+Columbidae	Columbidae	Bird
+Coracopsis vasa	Coracopsis	Bird
+Coragyps atratus	Coragyps	Bird
+Corvidae	Corvidae	Bird
+Corvus	Corvus	Bird
+Corvus brachyrhynchos	Corvus	Bird
+Corvus corax	Corvus	Bird
+Corvus cornix	Corvus	Bird
+Corvus corone	Corvus	Bird
+Corvus frugilegus	Corvus	Bird
+Corvus ossifragus	Corvus	Bird
+Cuculus canorus	Cuculus	Bird
+Curruca conspicillata	Curruca	Bird
+Cyanistes caeruleus	Cyanistes	Bird
+Cyanocitta cristata	Cyanocitta	Bird
+Cygnus buccinator	Cygnus	Bird
+Cygnus olor	Cygnus	Bird
+Dumetella	Dumetella	Bird
+Egretta garzetta	Egretta	Bird
+Euphagus cyanocephalus	Euphagus	Bird
+Falco	Falco	Bird
+Falco columbarius	Falco	Bird
+Falco peregrinus	Falco	Bird
+Falco punctatus	Falco	Bird
+Falco sparverius	Falco	Bird
+Falco tinnunculus	Falco	Bird
+Fringillidae	Fringillidae	Bird
+Fulica	Fulica	Bird
+Galliformes	Galliformes	Bird
+Gallus gallus	Gallus	Bird
+Garrulus glandarius	Garrulus	Bird
+Gymnogyps californianus	Gymnogyps	Bird
+Haemorhous mexicanus	Haemorhous	Bird
+Haliaeetus albicilla	Haliaeetus	Bird
+Haliaeetus leucocephalus	Haliaeetus	Bird
+Hirundinidae	Hirundinidae	Bird
+Hirundo rustica	Hirundo	Bird
+Hylocichla mustelina	Hylocichla	Bird
+Ichthyaetus leucophthalmus	Ichthyaetus	Bird
+Ictinia mississippiensis	Ictinia	Bird
+Lanius ludovicianus	Lanius	Bird
+Larus crassirostris	Larus	Bird
+Larus delawarensis	Larus	Bird
+Larus michahellis	Larus	Bird
+Larus smithsonianus	Larus	Bird
+Lathamus discolor	Lathamus	Bird
+Locustella naevia	Locustella	Bird
+Loriini	Loriini	Bird
+Meleagris gallopavo	Meleagris	Bird
+Mergus squamatus	Mergus	Bird
+Mimus	Mimus	Bird
+Mimus polyglottos	Mimus	Bird
+Molothrus ater	Molothrus	Bird
+Nestor notabilis	Nestor	Bird
+Oena capensis	Oena	Bird
+Oriolus flavocinctus	Oriolus	Bird
+Pandion haliaetus	Pandion	Bird
+Parulidae	Parulidae	Bird
+Parus major	Parus	Bird
+Passer domesticus	Passer	Bird
+Passer sp.	Passer	Bird
+Passeridae	Passeridae	Bird
+Passeriformes	Passeridae	Bird
+Pelecanus	Pelecanus	Bird
+Pelecanus erythrorhynchos	Pelecanus	Bird
+Pelecanus occidentalis	Pelecanus	Bird
+Phalacrocoracidae	Phalacrocoracidae	Bird
+Phalacrocorax auritus	Phalacrocorax	Bird
+Phalacrocorax carbo	Phalacrocorax	Bird
+Phasianinae	Phasianinae	Bird
+Phasianus colchicus	Phasianus	Bird
+Pheucticus melanocephalus	Pheucticus	Bird
+Phoenicoparrus andinus	Phoenicoparrus	Bird
+Phoenicopterus chilensis	Phoenicopterus	Bird
+Phoenicopterus roseus	Phoenicopterus	Bird
+Phoenicopterus ruber	Phoenicopterus	Bird
+Phoenicopterus sp.	Phoenicopterus	Bird
+Phylloscopus collybita	Phylloscopus	Bird
+Pica hudsonia	Pica	Bird
+Pica nuttalli	Pica	Bird
+Pica pica	Pica	Bird
+Pluvialis apricaria	Pluvialis	Bird
+Podiceps cristatus	Podiceps	Bird
+Poecile atricapillus	Poecile	Bird
+Poecile carolinensis	Poecile	Bird
+Prunella modularis	Prunella	Bird
+Pyrrhocorax graculus	Pyrrhocorax	Bird
+Quelea quelea	Quelea	Bird
+Quiscalus	Quiscalus	Bird
+Quiscalus major	Quiscalus	Bird
+Quiscalus quiscula	Quiscalus	Bird
+Rallus aquaticus	Rallus	Bird
+Serinus canaria	Serinus	Bird
+Spatula querquedula	Spatula	Bird
+Spheniscus humboldti	Spheniscus	Bird
+Spinus tristis	Spinus	Bird
+Sternula	Sternula	Bird
+Sternula antillarum	Sternula	Bird
+Streptopelia capicola	Streptopelia	Bird
+Streptopelia decaocto	Streptopelia	Bird
+Strigidae	Strigidae	Bird
+Strix aluco	Strix	Bird
+Strix nebulosa	Strix	Bird
+Strix nebulosa lapponica	Strix	Bird
+Sturnidae	Sturnidae	Bird
+Sturnus vulgaris	Sturnus	Bird
+Sylvia atricapilla	Sylvia	Bird
+Toxostoma rufum	Toxostoma	Bird
+Trichoglossus haematodus	Trichoglossus	Bird
+Trichoglossus moluccanus	Trichoglossus	Bird
+Turdus merula	Turdus	Bird
+Turdus migratorius	Turdus	Bird
+Turdus philomelos	Turdus	Bird
+Tyto alba	Tyto	Bird
+Zenaida macroura	Zenaida	Bird
+Equus caballus	Equus	Horse
+Equus caballus x Equus asinus	Equus	Horse
+Alectorobius capensis	Alectorobius	Tick
+Dermacentor marginatus	Dermacentor	Tick
+Hyalomma	Hyalomma	Tick
+Hyalomma marginatum	Hyalomma	Tick
+Hyalomma marginatum marginatum	Hyalomma	Tick
+Hyalomma plumbeum plumbeum	Hyalomma	Tick
+Hyalomma scupense	Hyalomma	Tick
+Ixodoidea	Ixodoidea	Tick
+Rhipicephalus guilhoni	Rhipicephalus	Tick
+Rhipicephalus pulchellus	Rhipicephalus	Tick
+Rhipicephalus rossicus	Rhipicephalus	Tick
+Bos taurus	Bos	Other
+Camelus bactrianus	Camelus	Other
+Camelus dromedarius	Camelus	Other
+Canis lupus familiaris	Canis	Other
+Chiroptera	Chiroptera	Other
+Cricetinae	Cricetinae	Other
+Crocodylus moreletii	Crocodylus	Other
+Crocodylus niloticus	Crocodylus	Other
+Crocodylus porosus	Crocodylus	Other
+Equus	Equus	Other
+Equus asinus	Equus	Other
+Equus ferus	Equus	Other
+Giraffa giraffa	Giraffa	Other
+Laridae	Laridae	Other
+Mastomys erythroleucus	Mastomys	Other
+Mephitis mephitis	Mephitis	Other
+Mesocricetus auratus	Mesocricetus	Other
+Mus musculus	Mus	Other
+Orcinus orca	Orcinus	Other
+Ovis aries	Ovis	Other
+Panthera leo	Panthera	Other
+Pelophylax ridibundus	Pelophylax	Other
+Platycercus	Platycercus	Other
+Rodentia	Rodentia	Other
+Rousettus leschenaultii	Rousettus	Other
+Sciuridae	Sciuridae	Other
+Sciurus carolinensis	Sciurus	Other
+Sciurus niger	Sciurus	Other
+Syncerus caffer	Syncerus	Other
+Vicugna pacos	Vicugna	Other

--- a/ingest/defaults/host_hostgenus_hosttype_map.tsv
+++ b/ingest/defaults/host_hostgenus_hosttype_map.tsv
@@ -1,11 +1,16 @@
 host	host_genus	host_type
 Homo sapiens	Homo	Human
 Aedeomyia madagascarica	Aedeomyia	Mosquito
+Aedes aegypti	Aedes	Mosquito
+Aedes africanus	Aedes	Mosquito
 Aedes albopictus	Aedes	Mosquito
 Aedes cinereus	Aedes	Mosquito
 Aedes dalzieli	Aedes	Mosquito
 Aedes japonicus	Aedes	Mosquito
+Aedes luteocephalus	Aedes	Mosquito
+Aedes niveus	Aedes	Mosquito
 Aedes rossicus	Aedes	Mosquito
+Aedes taylori	Aedes	Mosquito
 Aedes sp.	Aedes	Mosquito
 Aedes vexans	Aedes	Mosquito
 Anopheles atroparvus	Anopheles	Mosquito
@@ -61,6 +66,7 @@ Culiseta longiareolata	Culiseta	Mosquito
 Culiseta melanura	Culiseta	Mosquito
 Culiseta morsitans	Culiseta	Mosquito
 Mansonia uniformis	Mansonia	Mosquito
+Melanoconion	Culex	Mosquito
 Ochlerotatus canadensis	Ochlerotatus	Mosquito
 Ochlerotatus cantator	Ochlerotatus	Mosquito
 Ochlerotatus caspius	Ochlerotatus	Mosquito
@@ -77,6 +83,18 @@ Psorophora	Psorophora	Mosquito
 Psorophora ferox	Psorophora	Mosquito
 Uranotaenia	Uranotaenia	Mosquito
 Uranotaenia unguiculata	Uranotaenia	Mosquito
+Artibeus jamaicensis	Artibeus	Bat
+Artibeus phaeotis	Artibeus	Bat
+Carollia perspicillata	Carollia	Bat
+Glossophaga mutica	Glossophaga	Bat
+Glossophaga soricina	Glossophaga	Bat
+Molossus nigricans	Molossus	Bat
+Molossus pretiosus	Molossus	Bat
+Molossus rufus	Molossus	Bat
+Molossus sinaloae	Molossus	Bat
+Phyllostomus discolor	Phyllostomus	Bat
+Rhogeessa tumida	Rhogeessa	Bat
+Sturnira parvidens	Sturnira	Bat
 Accipiter	Accipiter	Bird
 Accipiter cooperii	Accipiter	Bird
 Accipiter gentilis	Accipiter	Bird
@@ -258,20 +276,28 @@ Ixodoidea	Ixodoidea	Tick
 Rhipicephalus guilhoni	Rhipicephalus	Tick
 Rhipicephalus pulchellus	Rhipicephalus	Tick
 Rhipicephalus rossicus	Rhipicephalus	Tick
+Arthropoda	Arthropoda	Other arthopod
+Chironomus thummi	Chironomus	Other arthopod
 Bos taurus	Bos	Other
+Callithrix penicillata	Callithrix	Other
 Camelus bactrianus	Camelus	Other
 Camelus dromedarius	Camelus	Other
 Canis lupus familiaris	Canis	Other
 Chiroptera	Chiroptera	Other
+Chlorocebus aethiops	Chlorocebus	Other
 Cricetinae	Cricetinae	Other
 Crocodylus moreletii	Crocodylus	Other
 Crocodylus niloticus	Crocodylus	Other
 Crocodylus porosus	Crocodylus	Other
+Didelphis marsupialis	Didelphis	Other
 Equus	Equus	Other
 Equus asinus	Equus	Other
 Equus ferus	Equus	Other
 Giraffa giraffa	Giraffa	Other
 Laridae	Laridae	Other
+Macaca fascicularis	Macaca	Other
+Macaca nemestrina	Macaca	Other
+Marmosa murina	Marmosa	Other
 Mastomys erythroleucus	Mastomys	Other
 Mephitis mephitis	Mephitis	Other
 Mesocricetus auratus	Mesocricetus	Other
@@ -280,11 +306,15 @@ Orcinus orca	Orcinus	Other
 Ovis aries	Ovis	Other
 Panthera leo	Panthera	Other
 Pelophylax ridibundus	Pelophylax	Other
+Proechimys cuvieri	Proechimys	Other
 Platycercus	Platycercus	Other
 Rodentia	Rodentia	Other
 Rousettus leschenaultii	Rousettus	Other
 Sciuridae	Sciuridae	Other
 Sciurus carolinensis	Sciurus	Other
 Sciurus niger	Sciurus	Other
+Simiiformes	Simiiformes	Other
 Syncerus caffer	Syncerus	Other
+Trachypithecus cristatus	Trachypithecus	Other
+Tupaia glis	Tupaia	Other
 Vicugna pacos	Vicugna	Other

--- a/ingest/rules/curate.smk
+++ b/ingest/rules/curate.smk
@@ -31,6 +31,7 @@ rule curate:
         sequences_ndjson="data/ncbi.ndjson",
         geolocation_rules=config["curate"]["local_geolocation_rules"],
         annotations=config["curate"]["annotations"],
+        manual_mapping="defaults/host_hostgenus_hosttype_map.tsv",
     output:
         metadata="data/all_metadata_curated.tsv",
         sequences="results/sequences_all.fasta",
@@ -81,6 +82,12 @@ rule curate:
                 --geolocation-rules {input.geolocation_rules} \
             | ./scripts/infer-dengue-serotype.py \
                 --out-col {params.serotype_field} \
+            | ./scripts/transform-new-fields \
+                --map-tsv {input.manual_mapping} \
+                --map-id host \
+                --metadata-id host \
+                --map-fields host_genus host_type \
+                --pass-through true \
             | augur curate apply-record-annotations \
                 --annotations {input.annotations} \
                 --id-field {params.annotations_id} \

--- a/ingest/scripts/transform-new-fields
+++ b/ingest/scripts/transform-new-fields
@@ -1,0 +1,50 @@
+#! /usr/bin/env python3
+
+import argparse
+import json
+import csv
+from sys import stdin, stdout
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Transform JSON data by applying a TSV mapping and adding new columns."
+    )
+    parser.add_argument("--map-tsv", required=True,
+        help="Path to the TSV mapping file.")
+    parser.add_argument("--map-id", required=True,
+        help="Column name in the map TSV to use as the mapping key.")
+    parser.add_argument("--metadata-id", required=True,
+        help="Column name in the metadata JSON to use as the mapping key.")
+    parser.add_argument("--map-fields", nargs="+", required=True,
+        help="Columns to add from the mapping file.")
+    parser.add_argument("--pass-through", default=False,
+        help="If set, pass through the original value when no mapping is found.")
+    return parser.parse_args()
+
+def load_mapping(map_tsv, map_id, map_fields):
+    mapping = {}
+    with open(map_tsv, 'r', encoding='utf-8') as f:
+        reader = csv.DictReader(f, delimiter='\t')
+        for row in reader:
+            key = row[map_id]
+            mapping[key] = {col: row[col] for col in map_fields}
+    return mapping
+
+def main():
+    args = parse_args()
+    mapping = load_mapping(args.map_tsv, args.map_id, args.map_fields)
+
+    for line in stdin:
+        record = json.loads(line)
+        key = record.get(args.metadata_id, '')
+
+        if key in mapping:
+            record.update(mapping[key])
+        elif args.pass_through:
+            for col in args.map_fields:
+                record[col] = record.get(args.metadata_id, '')
+
+        stdout.write(json.dumps(record) + '\n')
+
+if __name__ == "__main__":
+    main()

--- a/phylogenetic/rules/export.smk
+++ b/phylogenetic/rules/export.smk
@@ -97,6 +97,21 @@ rule prepare_auspice_config:
                 "key": "minor_lineage",
                 "title": "Minor lineage (Nextclade)",
                 "type": "categorical"
+              },
+              {
+                "key": "host",
+                "title": "Host Species",
+                "type": "categorical"
+              },
+              {
+                "key": "host_genus",
+                "title": "Host Genus",
+                "type": "categorical"
+              },
+              {
+                "key": "host_type",
+                "title": "Host Type",
+                "type": "categorical"
               }
             ],
             "geo_resolutions": [


### PR DESCRIPTION
## Description of proposed changes

Add host annotations to the phylogenetic trees. This also includes creating a more general "Host Genus" and "Host Type" coloring similar to the [WNV host annotations merged PR](https://github.com/nextstrain/WNV/pull/42). 

## Related issue(s)

## Checklist

- [ ] Checks pass

Staged the host colored phylogenetic trees below for review:


| serotype | genome                                                                                                    | E                                                                                               |
| :------- | :-------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
| all      | [all/genome](https://next.nextstrain.org/staging/dengue/trials/20250310host/dengue/all/genome?c=host)     | [all/E](https://next.nextstrain.org/staging/dengue/trials/20250310host/dengue/all/E?c=host)     |
| denv1    | [denv1/genome](https://next.nextstrain.org/staging/dengue/trials/20250310host/dengue/denv1/genome?c=host) | [denv1/E](https://next.nextstrain.org/staging/dengue/trials/20250310host/dengue/denv1/E?c=host) |
| denv2    | [denv2/genome](https://next.nextstrain.org/staging/dengue/trials/20250310host/dengue/denv2/genome?c=host) | [denv2/E](https://next.nextstrain.org/staging/dengue/trials/20250310host/dengue/denv2/E?c=host) |
| denv3    | [denv3/genome](https://next.nextstrain.org/staging/dengue/trials/20250310host/dengue/denv3/genome?c=host) | [denv3/E](https://next.nextstrain.org/staging/dengue/trials/20250310host/dengue/denv3/E?c=host) |
| denv4    | [denv4/genome](https://next.nextstrain.org/staging/dengue/trials/20250310host/dengue/denv4/genome?c=host) | [denv4/E](https://next.nextstrain.org/staging/dengue/trials/20250310host/dengue/denv4/E?c=host) |

