### PR TITLE
Avoid overriding the default parameters in the community-contributed Nextclade datasets

### DIFF
--- a/ingest/defaults/config.yaml
+++ b/ingest/defaults/config.yaml
@@ -120,8 +120,6 @@ curate:
   ]
 
 nextclade:
-  min_length: 1000 # E gene length is approximately 1400nt
-  min_seed_cover: 0.1
   gene: ["E","C","prM","NS1","NS2A","NS2B","NS3","NS4A","2K","NS4B","NS5"]
   # Nextclade Fields to rename to metadata field names.
   field_map:

--- a/ingest/rules/nextclade.smk
+++ b/ingest/rules/nextclade.smk
@@ -49,8 +49,6 @@ rule run_nextclade:
         translations=expand("data/v-gen-lab/{{serotype}}/translations/{gene}/seqs.gene.fasta", gene=config["nextclade"]["gene"]),
     threads: 4
     params:
-        min_length=config["nextclade"]["min_length"],
-        min_seed_cover=config["nextclade"]["min_seed_cover"],
         output_translations = lambda wildcards: f"data/v-gen-lab/{wildcards.serotype}/translations/{{cds}}/seqs.gene.fasta",
     log:
         "logs/v-gen-lab/{serotype}/run_nextclade.txt",
@@ -64,8 +62,6 @@ rule run_nextclade:
             --input-dataset {input.dataset} \
             -j {threads} \
             --output-tsv {output.nextclade} \
-            --min-length {params.min_length} \
-            --min-seed-cover {params.min_seed_cover} \
             --silent \
             --output-fasta {output.alignment} \
             --output-translations {params.output_translations} \


### PR DESCRIPTION
## Description of proposed changes

Instead of overriding default alignment parameters, use the parameters specified in the Nextclade dataset. This prevents unexpected results when Nextclade dataset developers define alignment parameters and downstream users also make adjustments.

## Related issue(s)

## Checklist


- [x] Checks pass
* [x] Run ingest: https://github.com/nextstrain/dengue/actions/workflows/ingest.yaml
* [x] Run phylogenetic push to staging: https://github.com/nextstrain/dengue/actions/runs/13925466984


|       | genome                                                                                                         | E gene                                                                                               |
| :---- | -------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
| all   | [all/genome](https://next.nextstrain.org/staging/dengue/trials/20250318/dengue/all/genome?c=major_lineage)     | [all/E](https://next.nextstrain.org/staging/dengue/trials/20250318/dengue/all/E?c=major_lineage)     |
| denv1 | [denv1/genome](https://next.nextstrain.org/staging/dengue/trials/20250318/dengue/denv1/genome?c=major_lineage) | [denv1/E](https://next.nextstrain.org/staging/dengue/trials/20250318/dengue/denv1/E?c=major_lineage) |
| denv2 | [denv2/genome](https://next.nextstrain.org/staging/dengue/trials/20250318/dengue/denv2/genome?c=major_lineage) | [denv2/E](https://next.nextstrain.org/staging/dengue/trials/20250318/dengue/denv2/E?c=major_lineage) |
| denv3 | [denv3/genome](https://next.nextstrain.org/staging/dengue/trials/20250318/dengue/denv3/genome?c=major_lineage) | [denv3/E](https://next.nextstrain.org/staging/dengue/trials/20250318/dengue/denv3/E?c=major_lineage) |
| denv4 | [denv4/genome](https://next.nextstrain.org/staging/dengue/trials/20250318/dengue/denv4/genome?c=major_lineage) | [denv4/E](https://next.nextstrain.org/staging/dengue/trials/20250318/dengue/denv4/E?c=major_lineage) |

