### PR TITLE
Add benchmark directives to phylogenetic, ingest, and nextclade workflows

### DIFF
--- a/.github/workflows/ingest.yaml
+++ b/.github/workflows/ingest.yaml
@@ -69,6 +69,7 @@ jobs:
           ingest \
             upload_all \
             --configfile build-configs/nextstrain-automation/config.yaml \
+            --stats benchmarks/stats.json \
             $CONFIG_OVERRIDES
       # Specifying artifact name to differentiate ingest build outputs from
       # the phylogenetic build outputs

--- a/.github/workflows/phylogenetic.yaml
+++ b/.github/workflows/phylogenetic.yaml
@@ -96,6 +96,7 @@ jobs:
             deploy_all \
             --configfile build-configs/nextstrain-automation/config.yaml \
             --set-threads align=1 tree=1 \
+            --stats benchmarks/stats.json \
             $CONFIG_OVERRIDES
       # Specifying artifact name to differentiate ingest build outputs from
       # the phylogenetic build outputs

--- a/ingest/rules/fetch_from_ncbi.smk
+++ b/ingest/rules/fetch_from_ncbi.smk
@@ -41,6 +41,8 @@ rule dump_ncbi_dataset_report:
         dataset_package="data/ncbi_dataset.zip",
     output:
         ncbi_dataset_tsv="data/ncbi_dataset_report_raw.tsv",
+    benchmark:
+        "benchmarks/dump_ncbi_dataset_report.txt"
     shell:
         """
         dataformat tsv virus-genome \

--- a/ingest/rules/nextclade.smk
+++ b/ingest/rules/nextclade.smk
@@ -20,6 +20,8 @@ rule get_nextclade_dataset:
     """Download Nextclade dataset"""
     output:
         dataset="data/nextclade_data/v-gen-lab/{serotype}.zip",
+    benchmark:
+        "benchmarks/{serotype}/get_nextclade_dataset.txt"
     params:
         dataset_name=lambda wildcards: f"community/v-gen-lab/dengue/{wildcards.serotype}",
     wildcard_constraints:

--- a/ingest/rules/split_serotypes.smk
+++ b/ingest/rules/split_serotypes.smk
@@ -21,6 +21,8 @@ rule split_by_serotype_genbank:
         sequences = "results/sequences_all.fasta"
     output:
         sequences = "results/sequences_{serotype}.fasta"
+    benchmark:
+        "benchmarks/{serotype}/split_by_serotype_genbank.txt"
     params:
         id_field = config["curate"]["output_id_field"],
         serotype_field = config["curate"]["serotype_field"]

--- a/nextclade/defaults/config_dengue.yaml
+++ b/nextclade/defaults/config_dengue.yaml
@@ -4,7 +4,7 @@
 sequences_url: "https://data.nextstrain.org/files/workflows/dengue/sequences_{serotype}.fasta.zst"
 metadata_url: "https://data.nextstrain.org/files/workflows/dengue/metadata_{serotype}.tsv.zst"
 
-strain_id_field: "genbank_accession"
+strain_id_field: "accession"
 display_strain_field: "strain"
 
 filter:

--- a/nextclade/rules/annotate_phylogeny.smk
+++ b/nextclade/rules/annotate_phylogeny.smk
@@ -29,6 +29,8 @@ rule ancestral:
         root_sequence = "resources/{serotype}/reference.fasta",
     output:
         node_data = "results/{gene}/nt-muts_{serotype}.json"
+    benchmark:
+        "benchmarks/{serotype}/{gene}/ancestral.txt"
     params:
         inference = "joint",
         reference = "../phylogenetic/config/reference_dengue_{serotype}.gb"
@@ -50,6 +52,8 @@ rule translate:
         reference = "resources/{serotype}/genome_annotation.gff3",
     output:
         node_data = "results/{gene}/aa-muts_{serotype}.json"
+    benchmark:
+        "benchmarks/{serotype}/{gene}/translate.txt"
     shell:
         """
         augur translate \
@@ -69,6 +73,8 @@ rule traits:
         metadata = "data/metadata_{serotype}.tsv"
     output:
         node_data = "results/{gene}/traits_{serotype}.json",
+    benchmark:
+        "benchmarks/{serotype}/{gene}/traits.txt"
     params:
         columns = lambda wildcards: config['traits']['traits_columns'][wildcards.serotype],
         sampling_bias_correction = config['traits']['sampling_bias_correction'],
@@ -94,6 +100,8 @@ rule clades:
         clade_defs = lambda wildcards: config['clades']['clade_definitions'][wildcards.serotype],
     output:
         clades = "results/genome/clades_{serotype}.json"
+    benchmark:
+        "benchmarks/{serotype}/genome/clades.txt"
     shell:
         """
         augur clades \

--- a/nextclade/rules/assemble_dataset.smk
+++ b/nextclade/rules/assemble_dataset.smk
@@ -27,6 +27,8 @@ rule assemble_dataset:
         annotation="datasets/{serotype}/genome_annotation.gff3",
         readme="datasets/{serotype}/README.md",
         changelog="datasets/{serotype}/CHANGELOG.md",
+    benchmark:
+        "benchmarks/{serotype}/assemble_dataset.txt"
     shell:
         """
         cp {input.reference} {output.reference}
@@ -48,6 +50,8 @@ rule test_dataset:
         changelog="datasets/{serotype}/CHANGELOG.md",
     output:
         outdir=directory("test_output/{serotype}"),
+    benchmark:
+        "benchmarks/{serotype}/test_dataset.txt"
     params:
         dataset_dir="datasets/{serotype}",
     shell:

--- a/nextclade/rules/construct_phylogeny.smk
+++ b/nextclade/rules/construct_phylogeny.smk
@@ -18,6 +18,8 @@ rule tree:
         alignment = "results/{gene}/aligned_{serotype}.fasta"
     output:
         tree = "results/{gene}/tree-raw_{serotype}.nwk"
+    benchmark:
+        "benchmarks/{serotype}/{gene}/tree.txt"
     shell:
         """
         augur tree \
@@ -41,6 +43,8 @@ rule refine:
     output:
         tree = "results/{gene}/tree_{serotype}.nwk",
         node_data = "results/{gene}/branch-lengths_{serotype}.json",
+    benchmark:
+        "benchmarks/{serotype}/{gene}/refine.txt"
     params:
         coalescent = "const",
         date_inference = "marginal",

--- a/nextclade/rules/export.smk
+++ b/nextclade/rules/export.smk
@@ -27,6 +27,8 @@ rule colors:
         metadata = "data/metadata_{serotype}.tsv",
     output:
         colors = "results/colors_{serotype}.tsv"
+    benchmark:
+        "benchmarks/{serotype}/colors.txt"
     shell:
         """
         python3 ../phylogenetic/scripts/assign-colors.py \
@@ -41,6 +43,8 @@ rule prepare_auspice_config:
     """Prepare the auspice config file for each serotypes"""
     output:
         auspice_config="results/config/{gene}/auspice_config_{serotype}.json",
+    benchmark:
+        "benchmarks/{serotype}/{gene}/prepare_auspice_config.txt"
     params:
         replace_clade_key=lambda wildcard: r"clade_membership" if wildcard.gene in ['genome'] else r"genotype_nextclade",
         replace_clade_title=lambda wildcard: r"Serotype" if wildcard.serotype in ['all'] else r"Dengue Genotype (Nextclade)",
@@ -143,6 +147,8 @@ rule export:
         colors = "results/colors_{serotype}.tsv",
     output:
         auspice_json = "results/{gene}/raw_dengue_{serotype}.json"
+    benchmark:
+        "benchmarks/{serotype}/{gene}/export.txt"
     params:
         strain_id = config.get("strain_id_field", "strain"),
     shell:
@@ -164,6 +170,8 @@ rule final_strain_name:
         metadata="data/metadata_{serotype}.tsv",
     output:
         auspice_json="auspice/dengue_{serotype}_{gene}.json"
+    benchmark:
+        "benchmarks/{serotype}/{gene}/final_strain_name.txt"
     params:
         strain_id=config.get("strain_id_field", "strain"),
         display_strain_field=config.get("display_strain_field", "strain"),

--- a/nextclade/rules/export.smk
+++ b/nextclade/rules/export.smk
@@ -99,7 +99,8 @@ rule prepare_auspice_config:
             ],
             "display_defaults": {
               "map_triplicate": True,
-              "color_by": params.replace_clade_key
+              "color_by": params.replace_clade_key,
+              "tip_label": "strain"
             },
             "filters": [
               "country",
@@ -107,7 +108,8 @@ rule prepare_auspice_config:
               "author"
             ],
             "metadata_columns": [
-              "genbank_accession"
+              "genbank_accession",
+              "strain"
             ]
           }
 
@@ -146,7 +148,7 @@ rule export:
         auspice_config = "results/config/{gene}/auspice_config_{serotype}.json",
         colors = "results/colors_{serotype}.tsv",
     output:
-        auspice_json = "results/{gene}/raw_dengue_{serotype}.json"
+        auspice_json = "auspice/dengue_{serotype}_{gene}.json"
     benchmark:
         "benchmarks/{serotype}/{gene}/export.txt"
     params:
@@ -161,26 +163,5 @@ rule export:
             --colors {input.colors} \
             --auspice-config {input.auspice_config} \
             --include-root-sequence-inline \
-            --output {output.auspice_json}
-        """
-
-rule final_strain_name:
-    input:
-        auspice_json="results/{gene}/raw_dengue_{serotype}.json",
-        metadata="data/metadata_{serotype}.tsv",
-    output:
-        auspice_json="auspice/dengue_{serotype}_{gene}.json"
-    benchmark:
-        "benchmarks/{serotype}/{gene}/final_strain_name.txt"
-    params:
-        strain_id=config.get("strain_id_field", "strain"),
-        display_strain_field=config.get("display_strain_field", "strain"),
-    shell:
-        """
-        python3 ../phylogenetic/scripts/set_final_strain_name.py \
-            --metadata {input.metadata} \
-            --metadata-id-columns {params.strain_id} \
-            --input-auspice-json {input.auspice_json} \
-            --display-strain-name {params.display_strain_field} \
             --output {output.auspice_json}
         """

--- a/nextclade/rules/prepare_sequences.smk
+++ b/nextclade/rules/prepare_sequences.smk
@@ -76,7 +76,7 @@ rule filter:
             --metadata-id-columns {params.strain_id} \
             --exclude {input.exclude} \
             --include {input.include} \
-            --output {output.sequences} \
+            --output-sequences {output.sequences} \
             --group-by {params.group_by} \
             --sequences-per-group {params.sequences_per_group} \
             --min-length {params.min_length} \

--- a/nextclade/rules/prepare_sequences.smk
+++ b/nextclade/rules/prepare_sequences.smk
@@ -19,7 +19,8 @@ rule download:
     output:
         sequences = "data/sequences_{serotype}.fasta.zst",
         metadata = "data/metadata_{serotype}.tsv.zst"
-
+    benchmark:
+        "benchmarks/{serotype}/download.txt"
     params:
         sequences_url = config["sequences_url"],
         metadata_url = config["metadata_url"],
@@ -37,6 +38,8 @@ rule decompress:
     output:
         sequences = "data/sequences_{serotype}.fasta",
         metadata = "data/metadata_{serotype}.tsv"
+    benchmark:
+        "benchmarks/{serotype}/decompress.txt"
     shell:
         """
         zstd -d -c {input.sequences} > {output.sequences}
@@ -58,6 +61,8 @@ rule filter:
         include = config["filter"]["include"],
     output:
         sequences = "results/{gene}/filtered_{serotype}.fasta"
+    benchmark:
+        "benchmarks/{serotype}/{gene}/filter.txt"
     params:
         group_by = config['filter']['group_by'],
         sequences_per_group = lambda wildcards: config['filter']['sequences_per_group'][wildcards.serotype],
@@ -87,6 +92,8 @@ rule add_outgorup:
         outgroup = lambda wildcard: config["outgroup"][wildcard.serotype],
     output:
         sequences = "results/{gene}/filtered_{serotype}_with_outgroup.fasta"
+    benchmark:
+        "benchmarks/{serotype}/{gene}/add_outgroup.txt"
     shell:
         """
         cat {input.sequences} {input.outgroup} > {output.sequences}
@@ -102,6 +109,8 @@ rule align:
         reference = "resources/{serotype}/reference.fasta",
     output:
         alignment = "results/{gene}/aligned_{serotype}.fasta"
+    benchmark:
+        "benchmarks/{serotype}/{gene}/align.txt"
     shell:
         """
         augur align \

--- a/nextclade/rules/prepare_sequences.smk
+++ b/nextclade/rules/prepare_sequences.smk
@@ -83,7 +83,7 @@ rule filter:
             --exclude-where country=? region=? date=? \
         """
 
-rule add_outgorup:
+rule add_outgroup:
     """
     Adding outgroup to the filtered sequences
     """

--- a/phylogenetic/rules/annotate_phylogeny.smk
+++ b/phylogenetic/rules/annotate_phylogeny.smk
@@ -28,6 +28,8 @@ rule ancestral:
         alignment = "results/{serotype}/{gene}/aligned.fasta",
     output:
         node_data = "results/{serotype}/{gene}/nt-muts.json"
+    benchmark:
+        "benchmarks/{serotype}/{gene}/ancestral.txt"
     params:
         inference = "joint"
     shell:
@@ -47,6 +49,8 @@ rule translate:
         reference = lambda wildcard: "defaults/{serotype}/reference.gb" if wildcard.gene in ['genome'] else "results/defaults/reference_{serotype}_{gene}.gb"
     output:
         node_data = "results/{serotype}/{gene}/aa-muts.json"
+    benchmark:
+        "benchmarks/{serotype}/{gene}/translate.txt"
     shell:
         """
         augur translate \
@@ -66,6 +70,8 @@ rule traits:
         metadata = "data/metadata_{serotype}.tsv"
     output:
         node_data = "results/{serotype}/{gene}/traits.json",
+    benchmark:
+        "benchmarks/{serotype}/{gene}/traits.txt"
     params:
         columns = lambda wildcards: config['traits']['traits_columns'][wildcards.serotype],
         sampling_bias_correction = config['traits']['sampling_bias_correction'],
@@ -91,6 +97,8 @@ rule clades:
         clade_defs = lambda wildcards: config['clades']['clade_definitions'][wildcards.serotype],
     output:
         clades = "results/{serotype}/genome/clades.json"
+    benchmark:
+        "benchmarks/{serotype}/genome/clades.txt"
     shell:
         """
         augur clades \

--- a/phylogenetic/rules/construct_phylogeny.smk
+++ b/phylogenetic/rules/construct_phylogeny.smk
@@ -18,6 +18,8 @@ rule tree:
         alignment = "results/{serotype}/{gene}/aligned.fasta"
     output:
         tree = "results/{serotype}/{gene}/tree-raw.nwk"
+    benchmark:
+        "benchmarks/{serotype}/{gene}/tree.txt"
     threads:
         8
     shell:
@@ -43,6 +45,8 @@ rule refine:
     output:
         tree = "results/{serotype}/{gene}/tree.nwk",
         node_data = "results/{serotype}/{gene}/branch-lengths.json",
+    benchmark:
+        "benchmarks/{serotype}/{gene}/refine.txt"
     params:
         coalescent = "const",
         date_inference = "marginal",

--- a/phylogenetic/rules/export.smk
+++ b/phylogenetic/rules/export.smk
@@ -27,6 +27,8 @@ rule colors:
         metadata = "data/metadata_{serotype}.tsv",
     output:
         colors = "results/{serotype}/colors.tsv"
+    benchmark:
+        "benchmarks/{serotype}/colors.txt"
     shell:
         """
         python3 scripts/assign-colors.py \
@@ -41,6 +43,8 @@ rule prepare_auspice_config:
     """Prepare the auspice config file for each serotypes"""
     output:
         auspice_config="results/defaults/{serotype}/{gene}/auspice_config.json",
+    benchmark:
+        "benchmarks/{serotype}/{gene}/prepare_auspice_config.txt"
     params:
         replace_clade_key=lambda wildcard: r"clade_membership" if wildcard.gene in ['genome'] else r"major_lineage",
         replace_clade_title=lambda wildcard: r"Serotype" if wildcard.serotype in ['all'] else r"Genotype (Nextclade)",
@@ -178,6 +182,8 @@ rule export:
         colors = "results/{serotype}/colors.tsv",
     output:
         auspice_json = "auspice/dengue_{serotype}_{gene}.json"
+    benchmark:
+        "benchmarks/{serotype}/{gene}/export.txt"
     params:
         strain_id = config.get("strain_id_field", "strain"),
     shell:
@@ -203,6 +209,8 @@ rule tip_frequencies:
         metadata = "data/metadata_{serotype}.tsv",
     output:
         tip_freq = "auspice/dengue_{serotype}_{gene}_tip-frequencies.json"
+    benchmark:
+        "benchmarks/{serotype}/{gene}/tip_frequencies.txt"
     params:
         strain_id = config["strain_id_field"],
         min_date = config["tip_frequencies"]["min_date"],

--- a/phylogenetic/rules/prepare_sequences.smk
+++ b/phylogenetic/rules/prepare_sequences.smk
@@ -76,7 +76,7 @@ rule filter:
             --metadata-id-columns {params.strain_id} \
             --exclude {input.exclude} \
             --include {input.include} \
-            --output {output.sequences} \
+            --output-sequences {output.sequences} \
             --group-by {params.group_by} \
             --subsample-max-sequences {params.subsample_max_sequences} \
             --min-length {params.min_length} \

--- a/phylogenetic/rules/prepare_sequences.smk
+++ b/phylogenetic/rules/prepare_sequences.smk
@@ -19,7 +19,8 @@ rule download:
     output:
         sequences = "data/sequences_{serotype}.fasta.zst",
         metadata = "data/metadata_{serotype}.tsv.zst"
-
+    benchmark:
+        "benchmarks/{serotype}/download.txt"
     params:
         sequences_url = config["sequences_url"],
         metadata_url = config["metadata_url"],
@@ -37,6 +38,8 @@ rule decompress:
     output:
         sequences = "data/sequences_{serotype}.fasta",
         metadata = "data/metadata_{serotype}.tsv"
+    benchmark:
+        "benchmarks/{serotype}/decompress.txt"
     shell:
         """
         zstd -d -c {input.sequences} > {output.sequences}
@@ -58,6 +61,8 @@ rule filter:
         include = config["filter"]["include"],
     output:
         sequences = "results/{serotype}/{gene}/filtered.fasta"
+    benchmark:
+        "benchmarks/{serotype}/{gene}/filter.txt"
     params:
         group_by = config['filter']['group_by'],
         subsample_max_sequences = config['filter']['subsample_max_sequences'],
@@ -89,6 +94,8 @@ rule align:
         reference = lambda wildcard: "defaults/{serotype}/reference.gb" if wildcard.gene in ['genome'] else "results/defaults/reference_{serotype}_{gene}.gb"
     output:
         alignment = "results/{serotype}/{gene}/aligned.fasta"
+    benchmark:
+        "benchmarks/{serotype}/{gene}/align.txt"
     threads: 8
     shell:
         """

--- a/phylogenetic/rules/prepare_sequences_E.smk
+++ b/phylogenetic/rules/prepare_sequences_E.smk
@@ -25,6 +25,8 @@ rule generate_E_reference_files:
     output:
         fasta = "results/defaults/reference_{serotype}_E.fasta",
         genbank = "results/defaults/reference_{serotype}_E.gb",
+    benchmark:
+        "benchmarks/{serotype}/generate_E_reference_files.txt"
     params:
         gene = "E",
     shell:
@@ -45,6 +47,8 @@ rule align_and_extract_E:
         reference = "results/defaults/reference_{serotype}_E.fasta"
     output:
         sequences = "results/{serotype}/E/sequences.fasta"
+    benchmark:
+        "benchmarks/{serotype}/align_and_extract_E.txt"
     params:
         min_length = 1000,
     shell:


### PR DESCRIPTION
## Description of proposed changes

From [this discussion](https://github.com/nextstrain/dengue/pull/105#issuecomment-2887260133) and since the phylogenetic workflow takes approximately 4 hours to complete when building 10 trees, added some benchmarking directives.

I also added a `--stats` flag to the GitHub Action call, allowing us to drag and drop a `benchmarks/stats.json` file into https://blab.github.io/snakemake-stats/ for improved timeline visualization.

### Expanded to include:

Since I was working in this codebase anyway, this PR expanded to include the following updates:

* [x] Fixed an `augur filter --output` warning by switching to `augur filter --output-sequences`
* [x] Added benchmark directives to the `ingest` and the `nextclade` workflows for consistency
* [x] Realized that the `nextclade` workflow had been broken for a while, and submitted several fixups
	* [x] Added ID based on on `accession`
	* [x] Removed the `final_strain_name` work-around

The `nextclade` workflow had been outdated, particularly since we transitioned to using the community Nextclade dataset in the following merged PR

* https://github.com/nextstrain/dengue/pull/93

Nevertheless, maintaining a working `nextclade` workflow is still valuable as a code reference for others to follow.

## Related issue(s)

* Originally addressing https://github.com/nextstrain/dengue/issues/106

## Checklist

- [ ] Checks pass

