### PR TITLE
phylogenetic: Allow users to define serotypes and genes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ We use this CHANGELOG to document breaking changes, new features, bug fixes, and
 
 ## 2025
 
+* 02 October 2025: phylogenetic - new required config params `serotypes` and `genes`
+  to configure which builds to run. [PR #117][]
 * 12 June 2025: **Breaking change** phylogenetic - use manually curated `defaults/colors.tsv`
   for lineage colorings. [PR #109][]
 * 22 May 2025: Add `benchmark` directives to all workflows. Benchmarks are output
@@ -49,6 +51,7 @@ We use this CHANGELOG to document breaking changes, new features, bug fixes, and
 [PR #105]: https://github.com/nextstrain/dengue/pull/105
 [PR #108]: https://github.com/nextstrain/dengue/pull/108
 [PR #109]: https://github.com/nextstrain/dengue/pull/109
+[PR #117]: https://github.com/nextstrain/dengue/pull/117
 
 ## 2024
 

--- a/phylogenetic/Snakefile
+++ b/phylogenetic/Snakefile
@@ -1,7 +1,7 @@
 configfile: "defaults/config_dengue.yaml"
 
-serotypes = ['all', 'denv1', 'denv2', 'denv3', 'denv4']
-genes = ['genome', 'E']
+serotypes = config["serotypes"]
+genes = config["genes"]
 
 wildcard_constraints:
     serotype = "|".join(serotypes),

--- a/phylogenetic/Snakefile
+++ b/phylogenetic/Snakefile
@@ -1,5 +1,8 @@
 configfile: "defaults/config_dengue.yaml"
 
+include: "../shared/vendored/snakemake/config.smk"
+include: "rules/config.smk"
+
 serotypes = config["serotypes"]
 genes = config["genes"]
 

--- a/phylogenetic/build-configs/ci/config.yaml
+++ b/phylogenetic/build-configs/ci/config.yaml
@@ -1,2 +1,5 @@
+serotypes: ["all"]
+genes: ["genome", "E"]
+
 custom_rules:
   - build-configs/ci/copy_example_data.smk

--- a/phylogenetic/defaults/config_dengue.yaml
+++ b/phylogenetic/defaults/config_dengue.yaml
@@ -1,3 +1,7 @@
+# Define wildcards used for building trees in the workflow
+serotypes: ['all', 'denv1', 'denv2', 'denv3', 'denv4']
+genes: ['genome', 'E']
+
 # Sequences must be FASTA and metadata must be TSV
 # Both files must be zstd compressed
 # Both files must have a {serotype} expandable field to be replaced by all, denv1-denv4

--- a/phylogenetic/rules/config.smk
+++ b/phylogenetic/rules/config.smk
@@ -1,0 +1,14 @@
+"""
+This part of the workflow deals with the config
+"""
+
+# Expected values supported by the workflow
+SEROTYPES = {'all', 'denv1', 'denv2', 'denv3', 'denv4'}
+GENES = {'genome', 'E'}
+
+# Validate config values
+if not all(serotype in SEROTYPES for serotype in config["serotypes"]):
+    raise InvalidConfigError(f"Values for `config.serotypes` must be one of {sorted(SEROTYPES)!r}")
+
+if not all(gene in GENES for gene in config["genes"]):
+    raise InvalidConfigError(f"Values for `config.genes` must be one of {sorted(GENES)!r}")


### PR DESCRIPTION
## Description of proposed changes

Allow users to define serotypes and genes through the config. 
Includes config validation to ensure that user provided values are the expected values supported by the workflow. 

Also includes change to reduce CI runtime by only running a subset of the phylo builds.

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] Update changelog
- [x] Pre-merge: Update TBD date in changelog

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
