### PR TITLE
fix(nextclade): align dataset metadata with schema

### DIFF
--- a/nextclade/resources/all/pathogen.json
+++ b/nextclade/resources/all/pathogen.json
@@ -10,15 +10,13 @@
   "attributes": {
     "name": "Dengue virus All serotypes",
     "reference accession": "NC_002640",
-    "reference name": "dengue virus type 4"
+    "reference name": "dengue virus type 4",
+    "experimental": true
   },
   "compatibility": {
     "cli": "3.0.0-alpha.0",
     "web": "3.0.0-alpha.0"
   },
-  "deprecated": false,
-  "enabled": true,
-  "experimental": true,
   "files": {
     "changelog": "CHANGELOG.md",
     "examples": "sequences.fasta",

--- a/nextclade/resources/denv1/pathogen.json
+++ b/nextclade/resources/denv1/pathogen.json
@@ -10,15 +10,13 @@
   "attributes": {
     "name": "Dengue virus DENV1 genotypes",
     "reference accession": "NC_001477",
-    "reference name": "NC_001477"
+    "reference name": "NC_001477",
+    "experimental": true
   },
   "compatibility": {
     "cli": "3.0.0-alpha.0",
     "web": "3.0.0-alpha.0"
   },
-  "deprecated": false,
-  "enabled": true,
-  "experimental": true,
   "files": {
     "changelog": "CHANGELOG.md",
     "examples": "sequences.fasta",

--- a/nextclade/resources/denv2/pathogen.json
+++ b/nextclade/resources/denv2/pathogen.json
@@ -10,15 +10,13 @@
   "attributes": {
     "name": "Dengue virus DENV2 genotypes",
     "reference accession": "NC_001474",
-    "reference name": "NC_001474"
+    "reference name": "NC_001474",
+    "experimental": true
   },
   "compatibility": {
     "cli": "3.0.0-alpha.0",
     "web": "3.0.0-alpha.0"
   },
-  "deprecated": false,
-  "enabled": true,
-  "experimental": true,
   "files": {
     "changelog": "CHANGELOG.md",
     "examples": "sequences.fasta",

--- a/nextclade/resources/denv3/pathogen.json
+++ b/nextclade/resources/denv3/pathogen.json
@@ -10,15 +10,13 @@
   "attributes": {
     "name": "Dengue virus DENV3 genotypes",
     "reference accession": "NC_001475",
-    "reference name": "NC_001475"
+    "reference name": "NC_001475",
+    "experimental": true
   },
   "compatibility": {
     "cli": "3.0.0-alpha.0",
     "web": "3.0.0-alpha.0"
   },
-  "deprecated": false,
-  "enabled": true,
-  "experimental": true,
   "files": {
     "changelog": "CHANGELOG.md",
     "examples": "sequences.fasta",

--- a/nextclade/resources/denv4/pathogen.json
+++ b/nextclade/resources/denv4/pathogen.json
@@ -10,15 +10,13 @@
   "attributes": {
     "name": "Dengue virus DENV4 genotypes",
     "reference accession": "NC_002640",
-    "reference name": "NC_002640"
+    "reference name": "NC_002640",
+    "experimental": true
   },
   "compatibility": {
     "cli": "3.0.0-alpha.0",
     "web": "3.0.0-alpha.0"
   },
-  "deprecated": false,
-  "enabled": true,
-  "experimental": true,
   "files": {
     "changelog": "CHANGELOG.md",
     "examples": "sequences.fasta",


### PR DESCRIPTION
Move `experimental` from top level to `attributes` and remove obsolete `deprecated` and `enabled` fields from all 5 Nextclade dataset configs.

These top-level metadata fields are not defined in the pathogen.json schema and are silently ignored by Nextclade. The `experimental` flag belongs under `attributes`, where Nextclade reads it. The `enabled` field is not a valid dataset-level property (it is valid only on QC rule sub-objects).

| Field | Action | Datasets |
|---|---|---|
| `deprecated: false` | Remove (default is false) | all, denv1-4 |
| `experimental: true` | Move to `attributes.experimental` | all, denv1-4 |
| `enabled: true` | Remove (not in schema) | all, denv1-4 |

- [x] Move `experimental` into `attributes` in 5 dataset configs
- [x] Remove `deprecated` and `enabled` from 5 dataset configs

> :warning: The existing dataset in `nextclade_data` is already patched in nextstrain/nextclade_data#433, so no immediate resubmission is needed. But without this upstream fix, the misplaced fields will reappear on the next dataset submission from this workflow.

> :information_source: See [pathogen.json schema](https://github.com/nextstrain/nextclade/blob/master/packages/nextclade-schemas/input-pathogen-json.schema.json) for the `PathogenJson` and `PathogenAttributes` definitions.

1. Related to: nextstrain/nextclade_data#433